### PR TITLE
Task B1 of approved spec jarvis-memory/specs/skier/docs-site-revamp

### DIFF
--- a/docs/builtins/generateItemsTask.md
+++ b/docs/builtins/generateItemsTask.md
@@ -173,6 +173,13 @@ Each item template receives:
   excerpt: "First part of content...",
   link: "/posts/hello-world/",
 
+  // Ordered list of the page's headings, in document order.
+  // Each heading in `content` also carries a matching `id` anchor.
+  headings: [
+    { level: 2, text: "Getting Started", slug: "getting-started" },
+    { level: 3, text: "Install the CLI", slug: "install-the-cli" },
+  ],
+
   // From additionalVarsFn
   readingTime: 5,
 
@@ -181,6 +188,39 @@ Each item template receives:
   posts: [/* all posts */],
 }
 ```
+
+---
+
+## Heading Anchors & On-Page TOC
+
+Every heading in rendered Markdown is emitted with a slugged `id`, so headings
+are deep-linkable (e.g. `/posts/hello-world/#getting-started`). Slugs are
+lower-cased, punctuation-stripped, and collision-safe: repeated headings get
+`-2`, `-3`, … suffixes so every anchor on a page is unique.
+
+The same headings are exposed to the template as the `headings` array (in
+document order), which you can use to build a right-rail table of contents:
+
+```handlebars
+<nav class="toc">
+  <ul>
+    {{#each headings}}
+      <li class="toc-level-{{level}}">
+        <a href="#{{slug}}">{{text}}</a>
+      </li>
+    {{/each}}
+  </ul>
+</nav>
+```
+
+Each entry carries its `level`, so a small amount of CSS (e.g. hiding
+`.toc-level-1`, indenting `.toc-level-3`) is all it takes to render only the
+levels you want. Skier's built-in Handlebars environment ships a safe `#each`
+but no comparison helpers, so filter by level in CSS rather than in the
+template.
+
+> `headings` is populated by Skier's built-in Markdown renderer. If you supply a
+> custom `markdownRenderer`, it returns HTML only, so `headings` will be empty.
 
 ---
 

--- a/docs/markdown-frontmatter.md
+++ b/docs/markdown-frontmatter.md
@@ -87,6 +87,19 @@ Include the highlight.js CSS in your template:
 
 ---
 
+## Heading Anchors & Table of Contents
+
+Every rendered heading (`##` through `######`, and `#`) is given a slugged `id`,
+so any heading is directly linkable — `.../my-page/#getting-started`. Slugs are
+lower-cased with punctuation removed, and duplicates on the same page are made
+unique with `-2`, `-3`, … suffixes.
+
+The page's headings are also exposed to templates as an ordered `headings` array
+(`{ level, text, slug }` per heading), so you can render an on-page table of
+contents. See [generateItemsTask → Heading Anchors & On-Page TOC](./builtins/generateItemsTask.md#heading-anchors-on-page-toc).
+
+---
+
 ## Excerpts
 
 For post summaries, use a marker:

--- a/src/builtins/generateItemsTask/index.ts
+++ b/src/builtins/generateItemsTask/index.ts
@@ -1,4 +1,4 @@
-import { renderMarkdown } from '../../utils/markdown.js';
+import { renderMarkdown, renderMarkdownWithHeadings, Heading } from '../../utils/markdown.js';
 import { ensureDir, readFileUtf8, writeFileUtf8, stat } from '../../utils/fileHelpers.js';
 import { titleFromFilename, excerptFromMarkdown } from '../../utils/stringUtils.js';
 import { formatDateDisplay } from '../../utils/dateUtils.js';
@@ -49,6 +49,8 @@ export interface ItemisedRenderVars extends Record<string, unknown> {
   link: string;
   /** Rendered HTML content */
   content: string;
+  /** Ordered list of headings (level + text + slug) found while rendering, for on-page TOCs */
+  headings: Heading[];
 }
 
 /**
@@ -298,12 +300,18 @@ export function generateItemsTask(
           excerpt = await excerptFromMarkdown(rawMarkdown);
         }
 
-        // Render markdown to HTML
+        // Render markdown to HTML. The default renderer also emits slugged,
+        // collision-safe heading ids and returns the ordered heading list so
+        // templates can build deep-links and an on-page table of contents.
+        // Custom renderers are strings-only, so they surface no headings.
         let content: string;
+        let headings: Heading[] = [];
         if (typeof cfg.markdownRenderer === 'function') {
           content = await cfg.markdownRenderer(rawMarkdown);
         } else {
-          content = await renderMarkdown(rawMarkdown);
+          const rendered = await renderMarkdownWithHeadings(rawMarkdown);
+          content = rendered.html;
+          headings = rendered.headings;
         }
 
         // Apply link rewriting
@@ -343,6 +351,7 @@ export function generateItemsTask(
               ? cfg.linkFn({ section, itemName, meta: frontmatter })
               : `/${section ? section + '/' : ''}${itemName}.html`,
           content,
+          headings,
         };
 
         // Inject additional variables

--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -1,0 +1,81 @@
+import { renderMarkdown, renderMarkdownWithHeadings } from './markdown.js';
+
+describe('renderMarkdownWithHeadings', () => {
+  it('emits slugged id attributes on headings h2–h4', async () => {
+    const md = ['## Getting Started', '### Install the CLI', '#### First build'].join('\n\n');
+    const { html, headings } = await renderMarkdownWithHeadings(md);
+
+    expect(html).toContain('<h2 id="getting-started">Getting Started</h2>');
+    expect(html).toContain('<h3 id="install-the-cli">Install the CLI</h3>');
+    expect(html).toContain('<h4 id="first-build">First build</h4>');
+
+    expect(headings).toEqual([
+      { level: 2, text: 'Getting Started', slug: 'getting-started' },
+      { level: 3, text: 'Install the CLI', slug: 'install-the-cli' },
+      { level: 4, text: 'First build', slug: 'first-build' },
+    ]);
+  });
+
+  it('slugs h1 and deeper headings too', async () => {
+    const { html, headings } = await renderMarkdownWithHeadings('# Title\n\n##### Deep\n');
+    expect(html).toContain('<h1 id="title">Title</h1>');
+    expect(html).toContain('<h5 id="deep">Deep</h5>');
+    expect(headings.map((h) => h.level)).toEqual([1, 5]);
+  });
+
+  it('makes duplicate slugs collision-safe with -2, -3 suffixes', async () => {
+    const md = ['## Setup', '## Setup', '## Setup'].join('\n\n');
+    const { html, headings } = await renderMarkdownWithHeadings(md);
+
+    expect(headings.map((h) => h.slug)).toEqual(['setup', 'setup-2', 'setup-3']);
+    expect(html).toContain('<h2 id="setup">Setup</h2>');
+    expect(html).toContain('<h2 id="setup-2">Setup</h2>');
+    expect(html).toContain('<h2 id="setup-3">Setup</h2>');
+  });
+
+  it('uses plain text (no inline markup) for text and slug', async () => {
+    const { html, headings } = await renderMarkdownWithHeadings('## The `fast` **path** & more\n');
+
+    expect(headings).toEqual([
+      { level: 2, text: 'The fast path & more', slug: 'the-fast-path-more' },
+    ]);
+    // The rendered heading keeps its inline markup in the body…
+    expect(html).toContain('<code>fast</code>');
+    // …but the id is the clean slug.
+    expect(html).toContain('id="the-fast-path-more"');
+  });
+
+  it('is deterministic across calls (fresh slug state each render)', async () => {
+    const md = '## Notes\n\n## Notes\n';
+    const first = await renderMarkdownWithHeadings(md);
+    const second = await renderMarkdownWithHeadings(md);
+    expect(first.headings.map((h) => h.slug)).toEqual(['notes', 'notes-2']);
+    // A second, independent render restarts the counter rather than continuing it.
+    expect(second.headings.map((h) => h.slug)).toEqual(['notes', 'notes-2']);
+  });
+
+  it('falls back to "section" for headings with no sluggable characters', async () => {
+    const { headings } = await renderMarkdownWithHeadings('## ???\n\n## ???\n');
+    expect(headings.map((h) => h.slug)).toEqual(['section', 'section-2']);
+  });
+
+  it('strips frontmatter and still collects headings', async () => {
+    const md = '---\ntitle: Hi\n---\n\n## Body Heading\n';
+    const { html, headings } = await renderMarkdownWithHeadings(md);
+    expect(html).not.toContain('title: Hi');
+    expect(headings).toEqual([{ level: 2, text: 'Body Heading', slug: 'body-heading' }]);
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('returns html only and still applies heading ids', async () => {
+    const html = await renderMarkdown('## Hello World\n');
+    expect(typeof html).toBe('string');
+    expect(html).toContain('<h2 id="hello-world">Hello World</h2>');
+  });
+
+  it('preserves highlight.js code block rendering', async () => {
+    const html = await renderMarkdown('```js\nconst a = 1;\n```\n');
+    expect(html).toContain('<pre><code class="hljs language-js">');
+  });
+});

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,17 +1,100 @@
 import { marked } from 'marked';
 import hljs from 'highlight.js';
 
-const renderer = new marked.Renderer();
-renderer.code = (code, infostring) => {
-  const lang = (infostring || '').match(/\S*/)?.[0];
-  if (lang && hljs.getLanguage(lang)) {
-    const highlighted = hljs.highlight(code, { language: lang }).value;
-    return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
-  }
-  const auto = hljs.highlightAuto(code).value;
-  return `<pre><code class="hljs">${auto}</code></pre>`;
-};
-marked.setOptions({ renderer });
+/**
+ * A single heading extracted from a rendered markdown document.
+ *
+ * Exposed on the template render context (as `headings`) so templates can build
+ * an on-page table of contents / right-rail. The list is in document order.
+ */
+export interface Heading {
+  /** Heading level (1–6, from the number of `#`s). */
+  level: number;
+  /** Plain-text heading content (HTML tags and entities resolved). */
+  text: string;
+  /** Slugged, collision-safe anchor id — matches the `id` attribute emitted on the heading. */
+  slug: string;
+}
+
+/**
+ * The result of rendering markdown: the HTML plus the ordered list of headings
+ * that were found (and given anchor ids) while rendering.
+ */
+export interface RenderedMarkdown {
+  html: string;
+  headings: Heading[];
+}
+
+/**
+ * Converts a fragment of rendered inline HTML back to plain text: strips tags
+ * and resolves the handful of entities marked emits. Used for heading display
+ * text and slug generation, so a heading like `## The **fast** path` yields the
+ * text `The fast path` rather than markup.
+ */
+function htmlToText(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+/**
+ * GitHub-style slug: lower-cased, punctuation dropped, whitespace collapsed to
+ * single hyphens. Deterministic for a given input.
+ */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Builds a marked Renderer that:
+ *  - highlights fenced code with highlight.js (unchanged behaviour), and
+ *  - emits a slugged, collision-safe `id` on every heading while collecting the
+ *    heading list into `headings`.
+ *
+ * A fresh renderer (and fresh slug/heading state) is built per render call so
+ * concurrent renders never share the collision counter.
+ */
+function createRenderer(headings: Heading[]): InstanceType<typeof marked.Renderer> {
+  const renderer = new marked.Renderer();
+  const slugCounts = new Map<string, number>();
+
+  renderer.code = (code, infostring) => {
+    const lang = (infostring || '').match(/\S*/)?.[0];
+    if (lang && hljs.getLanguage(lang)) {
+      const highlighted = hljs.highlight(code, { language: lang }).value;
+      return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
+    }
+    const auto = hljs.highlightAuto(code).value;
+    return `<pre><code class="hljs">${auto}</code></pre>`;
+  };
+
+  renderer.heading = (text, level) => {
+    const plain = htmlToText(text);
+    const base = slugify(plain) || 'section';
+
+    // Collision-safe: first occurrence keeps `base`, later dupes get -2, -3, …
+    const seen = slugCounts.get(base) ?? 0;
+    slugCounts.set(base, seen + 1);
+    const slug = seen === 0 ? base : `${base}-${String(seen + 1)}`;
+
+    headings.push({ level, text: plain, slug });
+    const tag = `h${String(level)}`;
+    return `<${tag} id="${slug}">${text}</${tag}>\n`;
+  };
+
+  return renderer;
+}
 
 /**
  * Strips YAML frontmatter from markdown content.
@@ -26,10 +109,27 @@ function stripFrontmatter(md: string): string {
   return md;
 }
 
-export async function renderMarkdown(md: string): Promise<string> {
-  // Strip frontmatter before rendering
+/**
+ * Renders markdown to HTML and returns the ordered list of headings found.
+ *
+ * Every heading is emitted with a deterministic, collision-safe anchor `id`
+ * (duplicate slugs get `-2`, `-3`, … suffixes), giving pages deep-linkable
+ * anchors, and `headings` lets templates build an on-page table of contents.
+ */
+export async function renderMarkdownWithHeadings(md: string): Promise<RenderedMarkdown> {
   const content = stripFrontmatter(md);
-  let html = await marked.parse(content);
+  const headings: Heading[] = [];
+  const renderer = createRenderer(headings);
+  const html = await marked.parse(content, { renderer });
 
+  return { html, headings };
+}
+
+/**
+ * Renders markdown to HTML. Headings still receive anchor ids; callers that also
+ * need the heading list should use {@link renderMarkdownWithHeadings}.
+ */
+export async function renderMarkdown(md: string): Promise<string> {
+  const { html } = await renderMarkdownWithHeadings(md);
   return html;
 }


### PR DESCRIPTION
I'll start by exploring the repo structure and the existing renderer to understand the conventions.
Let me look at the existing tests, other renderMarkdown callers, and stringUtils.
Dependencies aren't installed. Let me install them.
Now I understand the codebase. Let me check the existing README/docs for how tasks/renderer are documented, and look at an existing builtin test to match test conventions.
Now let me write the enhanced renderer. First, rewrite `markdown.ts`:
Now wire headings into `generateItemsTask`'s render context:
Now let me write tests for the renderer. Let me check jest config first:
All 9 pass. Now run the full suite and lint to confirm no regressions:
All 17 suites / 60 tests pass (the ts-jest warnings are pre-existing config noise). Now lint, typecheck, and build:
CI runs prettier + build + test (not eslint), all of which must pass. `build` and `test` are green. The `generateItemsTask` eslint errors are pre-existing debt (CI doesn't run eslint), and my edits added none. Let me still keep my brand-new `markdown.ts` lint-clean and fix prettier:
Now let me update the docs to reflect the new render-context variable. Let me look at the relevant docs:
I'll update the Template Variables section to document `headings` plus add a TOC section:
Let me verify which Handlebars helpers actually exist so the doc example is accurate:
The environment only registers a safe `each` helper — no `eq`/`or`. Let me fix the doc example to use only helpers that exist:
Now let me add a note to the markdown-frontmatter doc and verify the docs build still works. Let me check the markdown-frontmatter doc's structure briefly:
Now let me run an end-to-end check by building the docs site to confirm heading ids actually appear in rendered output:
The actual slug is `heading-anchors-on-page-toc` (single hyphen — my slugify collapses runs). Let me fix the cross-link I wrote:
Let me confirm build artifacts are gitignored so I don't leave stray files, and do a final full verification:
All CI gates green (format ✓, build ✓, 60 tests ✓), build artifacts are gitignored, and the real docs build emits the anchors. Here's the summary.

---

## What this does

Task **B1** of the Skier docs-site revamp (spec: `jarvis-memory/specs/skier/docs-site-revamp.md`). Extends Skier's built-in Markdown renderer so every page gets deep-linkable heading anchors **and** exposes an ordered per-page headings list to templates — the two things the new three-column docs layout's right-rail TOC needs. No new plugin system, no bespoke machinery: this makes the existing renderer more capable, per James's binding precedent rule.

## The problem

`src/utils/markdown.ts` (marked + highlight.js) emitted bare `<h2>…</h2>` with no `id`s and returned only an HTML string — so there were no anchors to link to and nothing for a template to build a TOC from. It also relied on a module-load-time `marked.setOptions({ renderer })` global side-effect, whose reach depended on import order.

## What changed

**`src/utils/markdown.ts`** — the core of the change:
- Headings now render with a slugged `id` (`## Getting Started` → `<h2 id="getting-started">`). Slugs are GitHub-style (lower-cased, punctuation stripped, whitespace→`-`) and **collision-safe**: repeats on a page get `-2`, `-3`, … deterministically.
- New `renderMarkdownWithHeadings(md)` returns `{ html, headings }`, where `headings` is an ordered `{ level, text, slug }[]`. `text`/`slug` are derived from the heading's plain text, so inline markup (`## The \`fast\` **path**`) yields clean data while the rendered heading keeps its markup.
- `renderMarkdown(md)` is preserved as a thin wrapper returning just the HTML — **all existing callers are unaffected** and now get anchor ids for free.
- The renderer is now built **per render call** (fresh slug counter + headings array), replacing the global `setOptions`. This removes the import-order side-effect and makes concurrent/repeated renders independent and deterministic. All heading levels (h1–h6) are slugged and listed; templates filter to h2–h4 as they like — satisfies the "h2–h4 at least" outcome.

**`src/builtins/generateItemsTask/index.ts`** — wiring into the template context:
- Default rendering now uses `renderMarkdownWithHeadings`, and `headings` is added to `ItemisedRenderVars` and passed into every item's render context. A user-supplied custom `markdownRenderer` is HTML-only (as before), so `headings` is `[]` there — documented.

**Tests** — `src/utils/markdown.test.ts` (new, 9 cases): id emission on h2–h4, h1/deep levels, collision `-2/-3` suffixing, plain-text extraction from inline markup, cross-call determinism, empty-slug fallback (`section`), and frontmatter stripping. Existing suite stays green (60/60).

**Docs** — updated `docs/builtins/generateItemsTask.md` (new "Heading Anchors & On-Page TOC" section + `headings` in the template-variables reference) and `docs/markdown-frontmatter.md`. The TOC example uses only the `#each` helper Skier actually ships (no `eq`/`or` — those aren't registered), filtering levels via `toc-level-{{level}}` CSS classes.

## Testing evidence

- `npm test` → 17 suites, 60 tests pass. `npm run build` (tsc) clean. `npm run format:check` (a CI gate) clean.
- End-to-end: ran `npm run docs:build` and confirmed real output, e.g. `public/builtins/generateItemsTask.html` now contains `<h2 id="when-to-use">`, `<h2 id="configuration">`, etc.
- CI note: CircleCI gates are prettier + build + test (it does **not** run eslint); all three pass. My new `markdown.ts` is also eslint-clean.

## Deliberately not done (scope discipline)

- **No template/CSS TOC UI** — that's the design-led A5 work building on Demi's bundle; B1 only provides the data and anchors.
- **Left the pre-existing eslint debt in `generateItemsTask/index.ts` untouched** (unrelated to this change; not a CI gate).
- **Did not change `setGlobalFromMarkdownTask`** — it renders via its own `marked` call and was never a heading/TOC surface; touching it would be scope creep.
- Kept the change modular and side-effect-free (per-call renderer, extensible `{ html, headings }` shape) so the sibling renderer PRs (copy-code metadata, callouts, snippet transclusion) rebase cleanly.

SUMMARY: Skier's Markdown renderer now emits slugged, collision-safe heading `id` anchors and exposes an ordered per-page `headings` list to templates for on-page TOCs.

---
_Opened by Tom from Slack._