### PR TITLE
Task B3 of approved spec jarvis-memory/specs/skier/docs-site-revamp

### DIFF
--- a/docs/builtins/README.md
+++ b/docs/builtins/README.md
@@ -79,6 +79,7 @@ flowchart TD
 |------|-------------|
 | [generateFeedTask](./generateFeedTask.md) | Create RSS, Atom, and JSON feeds |
 | [generateSitemapTask](./generateSitemapTask.md) | Generate sitemap.xml |
+| [generateSearchIndexTask](./generateSearchIndexTask.md) | Emit a JSON search index for client-side search |
 
 ### Asset Tasks
 

--- a/docs/builtins/generateSearchIndexTask.md
+++ b/docs/builtins/generateSearchIndexTask.md
@@ -1,0 +1,157 @@
+---
+title: generateSearchIndexTask
+subcategory: Feeds & SEO
+order: 3
+---
+
+# generateSearchIndexTask
+
+Walk your rendered HTML pages and emit a lean JSON **search index** for client-side search — no external search service required.
+
+---
+
+## When to Use
+
+✅ Use `generateSearchIndexTask` when you want:
+
+- Fast, native, client-side search over your site
+- A stable JSON index (title, headings, body text, URL) a search UI can fetch
+- Search built from the **rendered** pages, so it indexes exactly what readers see
+
+It is the search counterpart to [generateNavDataTask](./generateNavDataTask.md): same task
+shape and registration, but it reads rendered HTML rather than Markdown source, and it strips
+that HTML down to searchable text.
+
+Run it **after** all page-generating tasks so it can see the finished pages.
+
+---
+
+## Quick Start
+
+```js
+generateSearchIndexTask({
+  scanDir: 'public',
+  outDir: 'public',
+  siteUrl: 'https://skier.ripixel.co.uk',
+})
+```
+
+**Output:** `public/search-index.json`
+
+---
+
+## Configuration
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `scanDir` | string | ✅ | Directory to scan for rendered `.html` files |
+| `outDir` | string | ✅ | Directory to write the index JSON into |
+| `fileName` | string | | Output filename (default: `'search-index.json'`) |
+| `siteUrl` | string | | Site root URL for absolute page URLs (default: root-relative) |
+| `contentSelector` | string | | Tag whose contents are indexed, scoping out chrome (default: `'main'`; use `'body'` for the whole page). Falls back to `<body>` if absent. |
+| `excludes` | string[] | | Glob patterns to exclude (merged with defaults `404.html`, `404/**`) |
+| `outputVar` | string | | If set, the index is also exposed on `globals[outputVar]` for downstream tasks |
+| `maxBodyLength` | number | | Cap each page's body text to N characters (default: `0` = no limit) |
+| `pretty` | boolean | | Pretty-print the JSON (default: `false` — compact keeps the payload lean) |
+
+---
+
+## What Gets Indexed
+
+For each page the task extracts:
+
+| Field | Source |
+|-------|--------|
+| `url` | Cleaned, extension-free page URL (`index.html` → `/`, `about.html` → `/about`) |
+| `title` | First `<h1>` in the content region, falling back to `<title>`, then the filename |
+| `headings` | Every `<h1>`–`<h6>` in document order, with `level` and (when present) an anchor `id` |
+| `body` | The content region with HTML stripped, entities decoded, and whitespace collapsed |
+
+To keep the payload lean and relevant, the task **scopes to `contentSelector`** (default `<main>`)
+and strips `<script>`, `<style>`, HTML comments, and in-content `<nav>` blocks (breadcrumbs,
+prev/next) before extracting text — so shared chrome like the sidebar, header, and footer is not
+repeated on every page.
+
+---
+
+## Output Structure
+
+```typescript
+interface SearchIndex {
+  pages: SearchIndexEntry[]; // sorted by URL for deterministic output
+}
+
+interface SearchIndexEntry {
+  url: string;               // clean page URL
+  title: string;             // page title
+  headings: SearchHeading[]; // headings in document order
+  body: string;              // plain, searchable text
+}
+
+interface SearchHeading {
+  text: string;              // heading text, HTML stripped
+  level: number;             // 1–6
+  id?: string;               // anchor slug for deep-linking, when present
+}
+```
+
+This format is a **stable contract** consumed by the client-side search UI. Fields are added
+additively; existing fields are not renamed or repurposed.
+
+Example entry:
+
+```json
+{
+  "url": "/getting-started",
+  "title": "Getting Started",
+  "headings": [
+    { "text": "Getting Started", "level": 1 },
+    { "text": "Install", "level": 2, "id": "install" }
+  ],
+  "body": "Install with npm. Run the CLI to build your site. Install Requirements Node 22 or later is required."
+}
+```
+
+---
+
+## Exclusions
+
+`404.html` and `404/**` are always excluded. Add your own patterns via `excludes` — they are
+**merged** with the defaults and logged at info level:
+
+```js
+generateSearchIndexTask({
+  scanDir: 'public',
+  outDir: 'public',
+  excludes: ['drafts/**', 'admin/**'],
+})
+```
+
+```
+ℹ Search index: excluded /404.html (matched pattern: 404.html)
+ℹ Search index: excluded /drafts/wip.html (matched pattern: drafts/**)
+```
+
+---
+
+## Pipeline Position
+
+Place after every page-generating task, alongside the sitemap:
+
+```js
+export default [
+  prepareOutputTask({ /* ... */ }),
+  generateItemsTask({ /* ... */ }),
+  generatePagesTask({ /* ... */ }),
+  generateSitemapTask({ scanDir: 'public', outDir: 'public' }),
+  generateSearchIndexTask({ scanDir: 'public', outDir: 'public' }), // ← after pages exist
+];
+```
+
+---
+
+## Related Tasks
+
+- [generateNavDataTask](./generateNavDataTask.md) — The task this one is modelled on (sidebar data)
+- [generateSitemapTask](./generateSitemapTask.md) — Same scan-and-clean-URL approach, for SEO
+- [generateItemsTask](./generateItemsTask.md) — Renders the pages this task indexes

--- a/skier.tasks.cjs
+++ b/skier.tasks.cjs
@@ -6,6 +6,7 @@ const {
   generateItemsTask,
   generateNavDataTask,
   generatePagesTask,
+  generateSearchIndexTask,
   setGlobalsTask,
 } = require('./dist/');
 
@@ -107,4 +108,12 @@ exports.tasks = [
       }
     },
   },
+
+  // Build the native client-side search index from the rendered pages.
+  // Runs last so it captures every generated page (including the aliased index).
+  generateSearchIndexTask({
+    scanDir: 'public',
+    outDir: 'public',
+    siteUrl: 'https://skier.ripixel.co.uk',
+  }),
 ];

--- a/src/builtins/generateSearchIndexTask/index.test.ts
+++ b/src/builtins/generateSearchIndexTask/index.test.ts
@@ -1,0 +1,189 @@
+import { generateSearchIndexTask, GenerateSearchIndexConfig, SearchIndex } from './index.js';
+import * as fs from 'fs-extra';
+import path from 'path';
+import type { TaskContext } from '../../types.js';
+
+describe('generateSearchIndexTask', () => {
+  const testInputDir = path.join(__dirname, 'testAssets', 'input');
+  const testOutDir = path.join(__dirname, 'testAssets', 'out');
+  const indexFile = path.join(testOutDir, 'search-index.json');
+
+  const createCtx = (): TaskContext => ({
+    debug: false,
+    globals: {},
+    logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+  });
+
+  const readIndex = async (): Promise<SearchIndex> =>
+    JSON.parse(await fs.readFile(indexFile, 'utf8'));
+
+  const findPage = (index: SearchIndex, url: string) => index.pages.find((p) => p.url === url);
+
+  beforeAll(async () => {
+    await fs.ensureDir(testOutDir);
+  });
+
+  afterAll(async () => {
+    await fs.remove(testOutDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(indexFile);
+  });
+
+  const run = async (config: GenerateSearchIndexConfig, ctx = createCtx()) => {
+    const task = generateSearchIndexTask(config);
+    return task.run(config, ctx);
+  };
+
+  it('writes search-index.json and excludes 404 by default', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    expect(await fs.pathExists(indexFile)).toBe(true);
+
+    const index = await readIndex();
+    const urls = index.pages.map((p) => p.url);
+    // index.html, getting-started.html, guide/index.html, no-main.html (404 excluded)
+    expect(urls).toEqual(['/', '/getting-started', '/guide/', '/no-main']);
+    expect(urls).not.toContain('/404');
+  });
+
+  it('extracts title from the first h1, not the <title> tag', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    const index = await readIndex();
+    expect(findPage(index, '/')!.title).toBe('Welcome to Skier');
+    expect(findPage(index, '/getting-started')!.title).toBe('Getting Started');
+  });
+
+  it('collects headings in order with levels and anchor ids', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    const index = await readIndex();
+
+    expect(findPage(index, '/')!.headings).toEqual([
+      { text: 'Welcome to Skier', level: 1, id: 'home' },
+      { text: 'Features', level: 2, id: 'features' },
+    ]);
+    expect(findPage(index, '/getting-started')!.headings).toEqual([
+      { text: 'Getting Started', level: 1 },
+      { text: 'Install', level: 2, id: 'install' },
+      { text: 'Requirements', level: 3, id: 'requirements' },
+    ]);
+  });
+
+  it('strips HTML to plain text and decodes entities', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    const body = findPage(await readIndex(), '/')!.body;
+    expect(body).toContain('Skier is a minimal static site generator');
+    expect(body).toContain('Composable & fast. No magic.');
+    // No markup leaks through
+    expect(body).not.toMatch(/[<>]/);
+  });
+
+  it('excludes chrome, in-content nav, scripts and styles from the body', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    const body = findPage(await readIndex(), '/')!.body;
+    // <script> content
+    expect(body).not.toContain('this must not be indexed');
+    // breadcrumb <nav> inside <main>
+    expect(body).not.toContain('Docs');
+    // chrome outside <main>
+    expect(body).not.toContain('Header Chrome');
+    expect(body).not.toContain('Footer Chrome');
+    expect(body).not.toContain('color: red');
+  });
+
+  it('produces root-relative URLs by default and absolute URLs with siteUrl', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    let index = await readIndex();
+    expect(findPage(index, '/')).toBeDefined();
+    expect(findPage(index, '/getting-started')).toBeDefined();
+    expect(findPage(index, '/guide/')).toBeDefined();
+
+    await run({
+      scanDir: testInputDir,
+      outDir: testOutDir,
+      siteUrl: 'https://skier.ripixel.co.uk/',
+    });
+    index = await readIndex();
+    const urls = index.pages.map((p) => p.url);
+    expect(urls).toContain('https://skier.ripixel.co.uk/');
+    expect(urls).toContain('https://skier.ripixel.co.uk/getting-started');
+    expect(urls).toContain('https://skier.ripixel.co.uk/guide/');
+    expect(urls.every((u) => !u.endsWith('.html'))).toBe(true);
+  });
+
+  it('falls back to <body> when the content selector is absent', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    const page = findPage(await readIndex(), '/no-main')!;
+    expect(page.title).toBe('Standalone');
+    expect(page.body).toContain('No main wrapper here.');
+  });
+
+  it('merges custom excludes with defaults', async () => {
+    await run({
+      scanDir: testInputDir,
+      outDir: testOutDir,
+      excludes: ['guide/**'],
+    });
+    const urls = (await readIndex()).pages.map((p) => p.url);
+    expect(urls).not.toContain('/guide/'); // custom exclude
+    expect(urls).not.toContain('/404'); // default still applies
+    expect(urls).toContain('/getting-started'); // others remain
+  });
+
+  it('logs excluded files at info level', async () => {
+    const ctx = createCtx();
+    await run({ scanDir: testInputDir, outDir: testOutDir }, ctx);
+    expect(ctx.logger.info).toHaveBeenCalledWith(expect.stringContaining('excluded /404.html'));
+  });
+
+  it('respects a custom fileName', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir, fileName: 'docs-search.json' });
+    expect(await fs.pathExists(path.join(testOutDir, 'docs-search.json'))).toBe(true);
+    await fs.remove(path.join(testOutDir, 'docs-search.json'));
+  });
+
+  it('truncates body text at maxBodyLength on a word boundary', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir, maxBodyLength: 20 });
+    const body = findPage(await readIndex(), '/')!.body;
+    expect(body.length).toBeLessThanOrEqual(20);
+    expect(body).not.toMatch(/\s$/); // trimmed, no dangling partial word gap
+  });
+
+  it('exposes the index on globals when outputVar is set', async () => {
+    const result = await run({
+      scanDir: testInputDir,
+      outDir: testOutDir,
+      outputVar: 'searchIndex',
+    });
+    expect(result).toHaveProperty('searchIndex');
+    const idx = (result as Record<string, SearchIndex>).searchIndex!;
+    expect(idx.pages.length).toBe(4);
+  });
+
+  it('returns no globals when outputVar is not set', async () => {
+    const result = await run({ scanDir: testInputDir, outDir: testOutDir });
+    expect(result).toEqual({});
+  });
+
+  it('emits deterministic, URL-sorted output', async () => {
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    const first = await fs.readFile(indexFile, 'utf8');
+    await fs.remove(indexFile);
+    await run({ scanDir: testInputDir, outDir: testOutDir });
+    const second = await fs.readFile(indexFile, 'utf8');
+    expect(first).toBe(second);
+
+    const urls = (await readIndex()).pages.map((p) => p.url);
+    expect(urls).toEqual([...urls].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('throws a config error when required fields are missing', async () => {
+    const ctx = createCtx();
+    // @ts-expect-error deliberately omitting required outDir
+    const task = generateSearchIndexTask({ scanDir: testInputDir });
+    // @ts-expect-error deliberately omitting required outDir
+    await expect(task.run({ scanDir: testInputDir }, ctx)).rejects.toThrow(
+      /Missing required config/,
+    );
+  });
+});

--- a/src/builtins/generateSearchIndexTask/index.ts
+++ b/src/builtins/generateSearchIndexTask/index.ts
@@ -1,0 +1,335 @@
+import type { TaskDef, SkierGlobals } from '../../types.js';
+import {
+  ensureDir,
+  writeFileUtf8,
+  readFileUtf8,
+  findFilesRecursive,
+} from '../../utils/fileHelpers.js';
+import { join, basename } from '../../utils/pathHelpers.js';
+import { throwTaskError, validateRequiredConfig } from '../../utils/errors.js';
+
+/** Default glob patterns excluded from the search index (kept in step with the sitemap task). */
+const DEFAULT_EXCLUDES = ['404.html', '404/**'];
+
+/**
+ * A single heading extracted from a page, in document order.
+ *
+ * `id` is populated when the rendered heading carries an `id` attribute (as
+ * produced once heading-anchor support lands), so search results can deep-link
+ * straight to the relevant section. It is omitted when no anchor is present.
+ */
+export interface SearchHeading {
+  /** Heading text with all inline HTML stripped */
+  text: string;
+  /** Heading level, 1–6 (from `<h1>`–`<h6>`) */
+  level: number;
+  /** Anchor slug for deep-linking, when the heading has an `id` */
+  id?: string;
+}
+
+/**
+ * One entry in the search index: everything a client-side search UI needs to
+ * find and rank a page, and nothing it doesn't.
+ */
+export interface SearchIndexEntry {
+  /** Clean, extension-free URL of the page (root-relative, or absolute if `siteUrl` is set) */
+  url: string;
+  /** Page title (first `<h1>`, falling back to `<title>`, then filename) */
+  title: string;
+  /** Headings in document order, for section-level matching and result grouping */
+  headings: SearchHeading[];
+  /** Plain, HTML-stripped, whitespace-collapsed body text for full-text matching */
+  body: string;
+}
+
+/**
+ * The complete search index document written to disk as JSON.
+ *
+ * This format is a stable public contract consumed by the client-side search
+ * UI (a separate task). Add fields additively; do not rename or repurpose
+ * existing ones.
+ */
+export interface SearchIndex {
+  /** All indexed pages, sorted by URL for deterministic output */
+  pages: SearchIndexEntry[];
+}
+
+export interface GenerateSearchIndexConfig {
+  /** Directory to scan for rendered `.html` pages */
+  scanDir: string;
+  /** Directory to write the search index JSON into */
+  outDir: string;
+  /** Output filename for the index (default: `'search-index.json'`) */
+  fileName?: string;
+  /** Site root URL for absolute page URLs (default: root-relative URLs) */
+  siteUrl?: string;
+  /**
+   * Tag name whose contents are indexed, scoping out shared chrome (sidebar,
+   * header, footer). Default: `'main'`. Use `'body'` to index the whole body.
+   * If the tag is not found on a page, the task falls back to `<body>`.
+   */
+  contentSelector?: string;
+  /** Glob patterns to exclude from the index. Merged with defaults (`404.html`, `404/**`). */
+  excludes?: string[];
+  /** If set, the index object is also exposed on `globals[outputVar]` for downstream tasks. */
+  outputVar?: string;
+  /** Cap each page's body text to this many characters (default: `0` = no limit). */
+  maxBodyLength?: number;
+  /** Pretty-print the JSON (default: `false` — compact output keeps the payload lean). */
+  pretty?: boolean;
+}
+
+/**
+ * Test whether a relative path matches a simple glob pattern.
+ * Supports `**` (any path segments), `*` (any filename chars), and literal matching.
+ */
+function matchesGlob(relPath: string, pattern: string): boolean {
+  const norm = relPath.replace(/^\/+/, '');
+  const pat = pattern.replace(/^\/+/, '');
+
+  const regexStr = pat
+    .split('**')
+    .map((segment) =>
+      segment
+        .split('*')
+        .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('[^/]*'),
+    )
+    .join('.*');
+
+  return new RegExp(`^${regexStr}$`).test(norm);
+}
+
+/**
+ * Clean a relative HTML path into a search-friendly URL.
+ * - `index.html` → `/`
+ * - `foo/index.html` → `/foo/`
+ * - `about.html` → `/about`
+ */
+function cleanUrl(relPath: string): string {
+  const url = '/' + relPath.replace(/^\/+/, '');
+
+  if (url === '/index.html') return '/';
+  if (url.endsWith('/index.html')) return url.slice(0, -'index.html'.length);
+  if (url.endsWith('.html')) return url.slice(0, -'.html'.length);
+  return url;
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+/** Decode the handful of HTML entities that survive tag-stripping into plain text. */
+function decodeEntities(str: string): string {
+  return str.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, ent: string) => {
+    if (ent[0] === '#') {
+      const isHex = ent[1] === 'x' || ent[1] === 'X';
+      const code = isHex ? parseInt(ent.slice(2), 16) : parseInt(ent.slice(1), 10);
+      return Number.isNaN(code) ? match : String.fromCodePoint(code);
+    }
+    const named = NAMED_ENTITIES[ent.toLowerCase()];
+    return named !== undefined ? named : match;
+  });
+}
+
+/** Strip all HTML from a fragment and normalise whitespace into searchable plain text. */
+function htmlToText(html: string): string {
+  const text = html
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ');
+  return decodeEntities(text).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Extract the inner HTML of the first `selector` element (or `<body>` when
+ * `selector` is empty/`'body'`). Returns `null` if the requested element is
+ * absent so the caller can fall back.
+ */
+function extractRegion(html: string, selector: string): string | null {
+  if (!selector || selector.toLowerCase() === 'body') {
+    const body = html.match(/<body\b[^>]*>([\s\S]*)<\/body>/i);
+    return body ? body[1]! : html;
+  }
+  const re = new RegExp(`<${selector}\\b[^>]*>([\\s\\S]*?)<\\/${selector}>`, 'i');
+  const match = html.match(re);
+  return match ? match[1]! : null;
+}
+
+/** Remove non-content elements (scripts, styles, comments, in-content nav) before indexing. */
+function cleanRegion(region: string): string {
+  return region
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<nav\b[^>]*>[\s\S]*?<\/nav>/gi, ' ');
+}
+
+/** Extract headings (with optional anchor ids) from a cleaned content region, in order. */
+function extractHeadings(region: string): SearchHeading[] {
+  const headings: SearchHeading[] = [];
+  const re = /<h([1-6])\b([^>]*)>([\s\S]*?)<\/h\1>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(region)) !== null) {
+    const level = parseInt(match[1]!, 10);
+    const text = htmlToText(match[3]!);
+    if (!text) continue;
+    const idMatch = match[2]!.match(/\bid\s*=\s*["']([^"']+)["']/i);
+    const heading: SearchHeading = { text, level };
+    if (idMatch) heading.id = idMatch[1];
+    headings.push(heading);
+  }
+  return headings;
+}
+
+/** Derive a page title: first `<h1>` in the content, then `<title>`, then the filename. */
+function extractTitle(fullHtml: string, region: string, fallback: string): string {
+  const h1 = region.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1) {
+    const text = htmlToText(h1[1]!);
+    if (text) return text;
+  }
+  const titleTag = fullHtml.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleTag) {
+    const text = htmlToText(titleTag[1]!);
+    if (text) return text;
+  }
+  return fallback;
+}
+
+/**
+ * Walks a directory of rendered HTML pages and emits a JSON search index for
+ * client-side search — one entry per page with its title, headings, plain-text
+ * body, and clean URL.
+ *
+ * Modelled on {@link generateNavDataTask} (same task shape and registration
+ * pattern) but reads rendered HTML rather than Markdown source, so it captures
+ * exactly what a reader sees. HTML is stripped to searchable text and shared
+ * chrome (sidebar/header/footer) is scoped out via `contentSelector`, keeping
+ * the payload lean. The output format is a stable contract for the search UI.
+ *
+ * @example
+ * generateSearchIndexTask({
+ *   scanDir: 'public',
+ *   outDir: 'public',
+ *   siteUrl: 'https://skier.ripixel.co.uk',
+ * })
+ * // → writes public/search-index.json
+ */
+export function generateSearchIndexTask(
+  config: GenerateSearchIndexConfig,
+): TaskDef<GenerateSearchIndexConfig, SkierGlobals> {
+  return {
+    name: 'generate-search-index',
+    title: `Generate search index from ${config.scanDir}`,
+    config,
+    run: async (cfg, ctx) => {
+      validateRequiredConfig(ctx, 'generate-search-index', cfg, ['scanDir', 'outDir']);
+
+      const {
+        scanDir,
+        outDir,
+        fileName = 'search-index.json',
+        siteUrl,
+        contentSelector = 'main',
+        excludes = [],
+        outputVar,
+        maxBodyLength = 0,
+        pretty = false,
+      } = cfg;
+
+      try {
+        await ensureDir(scanDir);
+
+        const allHtmlFiles = await findFilesRecursive(scanDir, '.html');
+        const relFiles = allHtmlFiles.map((f) =>
+          f.startsWith(scanDir) ? f.slice(scanDir.length).replace(/^\/+/, '') : f,
+        );
+
+        const excludePatterns = [...DEFAULT_EXCLUDES, ...excludes];
+        const excluded: { file: string; pattern: string }[] = [];
+        const includedFiles = relFiles.filter((rel) => {
+          for (const pattern of excludePatterns) {
+            if (matchesGlob(rel, pattern)) {
+              excluded.push({ file: rel, pattern });
+              return false;
+            }
+          }
+          return true;
+        });
+
+        for (const { file, pattern } of excluded) {
+          ctx.logger.info(`Search index: excluded /${file} (matched pattern: ${pattern})`);
+        }
+
+        if (includedFiles.length === 0) {
+          ctx.logger.warn('No HTML files found in scanDir for search index generation.');
+        }
+
+        const entries: SearchIndexEntry[] = [];
+        for (const rel of includedFiles) {
+          const html = await readFileUtf8(join(scanDir, rel));
+
+          let region = extractRegion(html, contentSelector);
+          if (region === null) {
+            ctx.logger.debug(
+              `Search index: <${contentSelector}> not found in /${rel}, falling back to <body>`,
+            );
+            region = extractRegion(html, 'body');
+          }
+          const cleaned = cleanRegion(region ?? '');
+
+          const fallbackTitle = basename(rel, '.html')
+            .split('/')
+            .pop()!
+            .replace(/-/g, ' ')
+            .replace(/\b\w/g, (c) => c.toUpperCase());
+
+          const title = extractTitle(html, cleaned, fallbackTitle);
+          const headings = extractHeadings(cleaned);
+
+          let body = htmlToText(cleaned);
+          if (maxBodyLength > 0 && body.length > maxBodyLength) {
+            body = body
+              .slice(0, maxBodyLength)
+              .replace(/\s+\S*$/, '')
+              .trim();
+          }
+
+          const url = siteUrl ? `${siteUrl.replace(/\/$/, '')}${cleanUrl(rel)}` : cleanUrl(rel);
+
+          entries.push({ url, title, headings, body });
+        }
+
+        // Sort by URL for stable, deterministic output across builds.
+        entries.sort((a, b) => a.url.localeCompare(b.url));
+
+        const index: SearchIndex = { pages: entries };
+
+        await ensureDir(outDir);
+        const outPath = join(outDir, fileName);
+        await writeFileUtf8(outPath, JSON.stringify(index, null, pretty ? 2 : 0) + '\n');
+
+        ctx.logger.debug(
+          `Generated search index at ${outPath} with ${entries.length} pages (${excluded.length} excluded)`,
+        );
+
+        return outputVar ? { [outputVar]: index } : {};
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith('[skier/')) {
+          throw err;
+        }
+        throwTaskError(
+          ctx,
+          'generate-search-index',
+          'Failed to generate search index',
+          err instanceof Error ? err : undefined,
+        );
+      }
+    },
+  };
+}

--- a/src/builtins/generateSearchIndexTask/testAssets/input/404.html
+++ b/src/builtins/generateSearchIndexTask/testAssets/input/404.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Not Found</title>
+  </head>
+  <body>
+    <main><h1>Page Not Found</h1></main>
+  </body>
+</html>

--- a/src/builtins/generateSearchIndexTask/testAssets/input/getting-started.html
+++ b/src/builtins/generateSearchIndexTask/testAssets/input/getting-started.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Skier Docs | Getting Started</title>
+  </head>
+  <body>
+    <main class="content">
+      <h1>Getting Started</h1>
+      <p>Install with npm. Run the CLI to build your site.</p>
+      <h2 id="install">Install</h2>
+      <h3 id="requirements">Requirements</h3>
+      <p>Node 22 or later is required.</p>
+    </main>
+  </body>
+</html>

--- a/src/builtins/generateSearchIndexTask/testAssets/input/guide/index.html
+++ b/src/builtins/generateSearchIndexTask/testAssets/input/guide/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Guide</title>
+  </head>
+  <body>
+    <main>
+      <h1>Guide Index</h1>
+      <p>An overview of the guides.</p>
+    </main>
+  </body>
+</html>

--- a/src/builtins/generateSearchIndexTask/testAssets/input/index.html
+++ b/src/builtins/generateSearchIndexTask/testAssets/input/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Skier Docs | Home</title>
+    <style>
+      .chrome {
+        color: red;
+      }
+    </style>
+  </head>
+  <body class="docs-layout">
+    <header>Global Header Chrome</header>
+    <div class="docs-container">
+      <aside class="sidebar">
+        <nav>Getting Started Guides Reference</nav>
+      </aside>
+      <main class="content">
+        <nav class="breadcrumbs"><a href="/">Docs</a> &rsaquo; <span>Home</span></nav>
+        <h1 id="home">Welcome to Skier</h1>
+        <p>Skier is a minimal static site generator. Build your pipeline with tasks.</p>
+        <h2 id="features">Features</h2>
+        <p>Composable &amp; fast. No magic.</p>
+        <script>
+          console.log('this must not be indexed');
+        </script>
+      </main>
+    </div>
+    <footer>Global Footer Chrome</footer>
+  </body>
+</html>

--- a/src/builtins/generateSearchIndexTask/testAssets/input/no-main.html
+++ b/src/builtins/generateSearchIndexTask/testAssets/input/no-main.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>No Main Page</title>
+  </head>
+  <body>
+    <h1>Standalone</h1>
+    <p>No main wrapper here.</p>
+  </body>
+</html>

--- a/src/builtins/index.ts
+++ b/src/builtins/index.ts
@@ -23,3 +23,10 @@ export {
   NavSection,
   NavItem,
 } from './generateNavDataTask/index.js';
+export {
+  generateSearchIndexTask,
+  GenerateSearchIndexConfig,
+  SearchIndex,
+  SearchIndexEntry,
+  SearchHeading,
+} from './generateSearchIndexTask/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export * from './builtins/generatePagesTask/index.js';
 export * from './builtins/generateSitemapTask/index.js';
 export * from './builtins/generatePaginatedItemsTask/index.js';
 export * from './builtins/generateNavDataTask/index.js';
+export * from './builtins/generateSearchIndexTask/index.js';
 // Add any new built-ins here as needed


### PR DESCRIPTION
Now I have a full picture. Let me write the new task.
Now register it in both index files:
Now the test fixtures:
Now let me build and run the tests for this task:
Dependencies aren't installed. Let me install:
Dependencies installed; just a strict-null type error in my test. Let me fix it:
Build clean. Now run the test suite:
All 15 pass. Now run the full suite plus lint/format to confirm nothing's broken:
CI runs prettier + build + test — no eslint gate. Let me confirm my lint output matches the existing codebase's baseline (so I'm consistent, not introducing new patterns) and that prettier passes:
Confirmed — the existing committed sitemap task has the identical eslint "errors", so eslint isn't a gate and I'm consistent with house style. But prettier **is** a CI gate. Let me format:
Format is clean repo-wide. Re-run tests to confirm the reformatted fixtures still pass:
All green. Now the docs page and dogfood wiring. Let me check doc ordering conventions:
Now create the docs page:
Add a row to the builtins README's Feed Tasks table so it's discoverable in the reference:
Now wire it into the docs site's own pipeline — this is the dogfood, and lets me verify it end-to-end against the real docs build:
Now build and run the real docs build to verify it composes and produces a sane index:
Let me confirm the angle brackets are decoded entities from code samples (correct — text the reader sees), not leaked markup:
All three are legitimate code-sample / prose text the reader sees (e.g. `body: '<p>HTML content</p>'` in a config example) — real markup is stripped, entities decoded correctly. Let me confirm `public/` is gitignored so the build artifact isn't committed:
`public/` is gitignored — the build artifact won't be committed. Final full verification pass:
All four CI gates pass locally (build, prettier, tests) and the task composes cleanly in the real docs build. This is a package/data change with no visual surface (it emits a JSON file; the search UI is the separate A6 task), so no screenshots apply.

---

## Task B3 — Native search index built-in task (`generateSearchIndexTask`)

**Spec:** `jarvis-memory/specs/skier/docs-site-revamp.md` (workstream B, item B3). Flagship dogfood proof-point; James chose **native search — no Algolia, no external service**.

### Problem
Skier had no way to produce a search index. The docs-site revamp needs client-side search, and the binding design principle for this workstream is that new capability lands **as a new built-in task the same way `generateNavDataTask` does** — no new plugin systems, no bespoke machinery, no external search service. Skier stays predictable and composable.

### What I changed
Added a new built-in task, **`generateSearchIndexTask`** (`src/builtins/generateSearchIndexTask/`), modelled directly on `generateNavDataTask` — same task shape (`TaskDef` factory, config interface with sensible defaults, JSDoc'd exported types), same registration pattern (exported from both `src/builtins/index.ts` and `src/index.ts`), clear inputs/outputs, composes in the pipeline.

It walks the **rendered** HTML pages (like `generateSitemapTask`, which is the right analogue for "index what the reader actually sees") and emits one lean JSON entry per page:

```jsonc
{ "pages": [ { "url": "/getting-started",
              "title": "Getting Started",
              "headings": [ { "text": "Install", "level": 2, "id": "install" } ],
              "body": "…plain, HTML-stripped, entity-decoded text…" } ] }
```

Key behaviours, chosen to keep the payload lean and the format stable:
- **Strips HTML to searchable text** — removes tags, decodes entities, collapses whitespace.
- **Scopes to a content region** (`contentSelector`, default `<main>`, falls back to `<body>`) and strips `<script>`/`<style>`/comments/in-content `<nav>` — so shared chrome (sidebar, header, footer, breadcrumbs, prev/next) is **not** repeated on every page.
- **Title** = first `<h1>` → `<title>` → filename; **headings** captured in order with `level` and (when present) an anchor `id` for future deep-linking (composes with B1 heading-anchors when that lands, degrades gracefully until then).
- **Clean URLs** and `404`-excludes reuse the same conventions as `generateSitemapTask`; `excludes` merges with defaults and logs at info level.
- **Deterministic** — entries sorted by URL, so rebuilds produce byte-identical output.
- Optional `siteUrl` (absolute vs root-relative URLs), `fileName`, `maxBodyLength`, `pretty`, and `outputVar` (also expose the index on globals for downstream tasks).

The output format is documented as a **stable contract** — additive changes only — so the A6 search UI can build against it safely.

### Dogfood wiring
Wired the task into the docs site's own pipeline (`skier.tasks.cjs`), running last so it captures every generated page. Verified end-to-end against the real docs build: it produces `public/search-index.json` — **26 pages, ~96 KB** — with correct titles, ordered headings (anchor ids already present in the rendered docs), and clean bodies (chrome/scripts excluded; the only angle brackets in bodies are decoded entities from code samples the reader sees, e.g. `body: '<p>HTML content</p>'`).

### Docs
Added `docs/builtins/generateSearchIndexTask.md` (config table, output structure, pipeline position, exclusions) following the existing built-in-doc template, and listed it in the built-ins reference README.

### Testing evidence
- `npm run build` (tsc) — clean.
- `npm run format:check` (prettier) — clean repo-wide.
- `npm test` — **75 passed / 75**, including **15 new tests** covering: file emission & 404 exclusion, title-from-h1, ordered headings with levels/ids, HTML stripping + entity decode, chrome/nav/script exclusion, root-relative vs absolute URLs, `<body>` fallback, custom excludes, custom filename, `maxBodyLength` word-boundary truncation, `outputVar` globals, deterministic sorted output, and required-config validation.
- Real docs build composes and emits a valid index (above).

CI note: the repo's CircleCI pipeline gates on prettier + build + test (no eslint job); all three pass. The task's eslint profile matches the existing `generateSitemapTask` exactly (same non-null-assertion warnings and template-literal patterns), so it's consistent with house style.

### What I deliberately did not do
- **No search UI** — consuming the index client-side is task A6, kept separate on purpose; this PR produces the index only.
- **No external service, no plugin system, no new dependency** — pure built-in task, per the binding design principle.
- Did not touch the renderer (B1/B2 anchors/copy-code are their own PRs); this task reads whatever ids the renderer emits and works with or without them.
- Left `public/` uncommitted (gitignored build artifact).

SUMMARY: Added `generateSearchIndexTask`, a new Skier built-in (modelled on `generateNavDataTask`) that walks rendered docs pages and emits a lean, stable JSON search index for native client-side search, wired into the docs build and covered by 15 tests.

---
_Opened by Tom from Slack._