### PR TITLE
I've just read <https://docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,14 @@ jobs:
             git config user.email "ci@skier.dev"
             git config user.name "CircleCI"
             git remote set-url origin git@github.com:ripixel/skier.git
-      - run: npx semantic-release
+      - run:
+          name: Publish via npm trusted publishing (OIDC)
+          command: |
+            # Exchange CircleCI's OIDC token for a short-lived npm publish token.
+            # semantic-release/npm >= 13.1 detects NPM_ID_TOKEN and uses trusted
+            # publishing instead of a long-lived NPM_TOKEN. No npm token required.
+            export NPM_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')"
+            npx semantic-release
   build_docs:
     executor: node-executor
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^11.0.6",
-        "@semantic-release/npm": "^12.0.0",
+        "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.1",
         "@types/clean-css": "^4.2.11",
         "@types/fs-extra": "^11.0.4",
@@ -47,6 +47,50 @@
       "engines": {
         "node": ">=22.17.0"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -3241,28 +3285,29 @@
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
-      "integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+      "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
+        "env-ci": "^11.2.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^8.0.0",
-        "npm": "^10.9.3",
+        "normalize-url": "^9.0.0",
+        "npm": "^11.6.2",
         "rc": "^1.2.8",
-        "read-pkg": "^9.0.0",
+        "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
         "tempy": "^3.0.0"
       },
       "engines": {
-        "node": ">=20.8.1"
+        "node": "^22.14.0 || >= 24.10.0"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
@@ -3368,6 +3413,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@semantic-release/npm/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@semantic-release/npm/node_modules/human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -3404,6 +3461,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@semantic-release/npm/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -3434,6 +3514,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@semantic-release/npm/node_modules/read-pkg": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+      "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.4.4",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/read-pkg/node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@semantic-release/npm/node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3455,6 +3566,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6545,9 +6671,9 @@
       }
     },
     "node_modules/env-ci": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.1.1.tgz",
-      "integrity": "sha512-mT3ks8F0kwpo7SYNds6nWj0PaRh+qJxIeBVBXAKTN9hphAzZv7s0QAZQbqnB1fAv/r4pJUGE15BV9UrS31FP2w==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
+      "integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
       "dev": true,
       "dependencies": {
         "execa": "^8.0.0",
@@ -11559,27 +11685,28 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.2.tgz",
-      "integrity": "sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+      "integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
       "dev": true,
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm": {
-      "version": "10.9.3",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.3.tgz",
-      "integrity": "sha512-6Eh1u5Q+kIVXeA8e7l2c/HpnFFcwrkt37xDMujD5be1gloWa9p6j3Fsv3mByXXmqJHy+2cElRMML8opNT7xIJQ==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/config",
         "@npmcli/fs",
         "@npmcli/map-workspaces",
+        "@npmcli/metavuln-calculator",
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
         "@npmcli/redact",
@@ -11590,7 +11717,6 @@
         "cacache",
         "chalk",
         "ci-info",
-        "cli-columns",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -11604,7 +11730,6 @@
         "libnpmdiff",
         "libnpmexec",
         "libnpmfund",
-        "libnpmhook",
         "libnpmorg",
         "libnpmpack",
         "libnpmpublish",
@@ -11618,7 +11743,6 @@
         "ms",
         "node-gyp",
         "nopt",
-        "normalize-package-data",
         "npm-audit-report",
         "npm-install-checks",
         "npm-package-arg",
@@ -11641,86 +11765,82 @@
         "tiny-relative-date",
         "treeverse",
         "validate-npm-package-name",
-        "which",
-        "write-file-atomic"
+        "which"
       ],
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/config": "^9.0.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^4.0.2",
-        "@npmcli/package-json": "^6.2.0",
-        "@npmcli/promise-spawn": "^8.0.2",
-        "@npmcli/redact": "^3.2.2",
-        "@npmcli/run-script": "^9.1.0",
-        "@sigstore/tuf": "^3.1.1",
-        "abbrev": "^3.0.1",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/map-workspaces": "^5.0.3",
+        "@npmcli/metavuln-calculator": "^9.0.3",
+        "@npmcli/package-json": "^7.0.5",
+        "@npmcli/promise-spawn": "^9.0.1",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
+        "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^19.0.1",
-        "chalk": "^5.4.1",
-        "ci-info": "^4.2.0",
-        "cli-columns": "^4.0.0",
+        "cacache": "^20.0.4",
+        "chalk": "^5.6.2",
+        "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.4.5",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^8.1.0",
-        "ini": "^5.0.0",
-        "init-package-json": "^7.0.2",
-        "is-cidr": "^5.1.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "libnpmaccess": "^9.0.0",
-        "libnpmdiff": "^7.0.1",
-        "libnpmexec": "^9.0.1",
-        "libnpmfund": "^6.0.1",
-        "libnpmhook": "^11.0.0",
-        "libnpmorg": "^7.0.0",
-        "libnpmpack": "^8.0.1",
-        "libnpmpublish": "^10.0.1",
-        "libnpmsearch": "^8.0.0",
-        "libnpmteam": "^7.0.0",
-        "libnpmversion": "^7.0.0",
-        "make-fetch-happen": "^14.0.3",
-        "minimatch": "^9.0.5",
-        "minipass": "^7.1.1",
+        "hosted-git-info": "^9.0.3",
+        "ini": "^6.0.0",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
+        "json-parse-even-better-errors": "^5.0.0",
+        "libnpmaccess": "^10.0.3",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
+        "libnpmorg": "^8.0.1",
+        "libnpmpack": "^9.1.11",
+        "libnpmpublish": "^11.2.0",
+        "libnpmsearch": "^9.0.1",
+        "libnpmteam": "^8.0.2",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
+        "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^11.2.0",
-        "nopt": "^8.1.0",
-        "normalize-package-data": "^7.0.0",
-        "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.1",
-        "npm-package-arg": "^12.0.2",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-profile": "^11.0.1",
-        "npm-registry-fetch": "^18.0.2",
-        "npm-user-validate": "^3.0.0",
-        "p-map": "^7.0.3",
-        "pacote": "^19.0.1",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "node-gyp": "^12.4.0",
+        "nopt": "^9.0.0",
+        "npm-audit-report": "^7.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.2",
+        "npm-pick-manifest": "^11.0.3",
+        "npm-profile": "^12.0.2",
+        "npm-registry-fetch": "^19.1.1",
+        "npm-user-validate": "^4.0.0",
+        "p-map": "^7.0.4",
+        "pacote": "^21.5.1",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^4.1.0",
-        "semver": "^7.7.2",
+        "read": "^5.0.1",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
-        "ssri": "^12.0.0",
-        "supports-color": "^9.4.0",
-        "tar": "^6.2.1",
+        "ssri": "^13.0.1",
+        "supports-color": "^10.2.2",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.1",
-        "which": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-install-checks": {
@@ -11801,71 +11921,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
+    "node_modules/npm/node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -11887,7 +11949,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "3.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11895,83 +11957,82 @@
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
+        "lru-cache": "^11.2.1",
         "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "8.0.1",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/metavuln-calculator": "^8.0.0",
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.1",
-        "@npmcli/query": "^4.0.0",
-        "@npmcli/redact": "^3.0.0",
-        "@npmcli/run-script": "^9.0.1",
-        "bin-links": "^5.0.0",
-        "cacache": "^19.0.1",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^8.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
-        "lru-cache": "^10.2.2",
-        "minimatch": "^9.0.4",
-        "nopt": "^8.0.0",
-        "npm-install-checks": "^7.1.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "pacote": "^19.0.0",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "proggy": "^3.0.0",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^3.0.1",
-        "read-package-json-fast": "^4.0.0",
         "semver": "^7.3.7",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.0",
         "treeverse": "^3.0.0",
-        "walk-up-path": "^3.0.1"
+        "walk-up-path": "^4.0.0"
       },
       "bin": {
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "9.0.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/package-json": "^6.0.1",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
         "ci-info": "^4.0.0",
-        "ini": "^5.0.0",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "ini": "^6.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "walk-up-path": "^3.0.1"
+        "walk-up-path": "^4.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11979,156 +12040,125 @@
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "6.0.3",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^8.0.0",
-        "ini": "^5.0.0",
-        "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^10.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "bin": {
         "installed-package-contents": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "4.0.2",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "glob": "^10.2.2",
-        "minimatch": "^9.0.0"
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "8.0.1",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cacache": "^19.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "pacote": "^20.0.0",
-        "proc-log": "^5.0.0",
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-      "version": "20.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "@npmcli/run-script": "^9.0.0",
-        "cacache": "^19.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^12.0.0",
-        "npm-packlist": "^9.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "6.2.0",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "glob": "^10.2.2",
-        "hosted-git-info": "^8.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.2",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "4.0.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12136,47 +12166,57 @@
         "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
-      "version": "3.2.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "9.1.0",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "node-gyp": "^11.0.0",
-        "proc-log": "^5.0.0",
-        "which": "^5.0.0"
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
+    "node_modules/npm/node_modules/@sigstore/bundle": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
       "engines": {
-        "node": ">=14"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/core": {
+      "version": "3.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.4.3",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -12184,17 +12224,48 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.1",
-        "tuf-js": "^3.0.1"
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
@@ -12206,17 +12277,30 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12224,29 +12308,8 @@
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -12258,123 +12321,77 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/bin-links": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^7.0.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "read-cmd-shim": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.3.0",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/binary-extensions": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "19.0.1",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^4.0.0",
+        "@npmcli/fs": "^5.0.0",
         "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
         "minipass": "^7.0.3",
         "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/chownr": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/tar": {
-      "version": "7.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "5.4.1",
+      "version": "5.6.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12386,16 +12403,16 @@
       }
     },
     "node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.2.0",
+      "version": "4.4.0",
       "dev": true,
       "funding": [
         {
@@ -12410,90 +12427,30 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.1.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^5.0.0"
-      },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
+        "node": ">=20"
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "7.0.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/cssesc": {
@@ -12509,7 +12466,7 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.4.1",
+      "version": "4.4.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12526,34 +12483,12 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.2.0",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
@@ -12565,14 +12500,8 @@
         "node": ">=6"
       }
     },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
@@ -12584,22 +12513,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/fs-minipass": {
@@ -12615,20 +12528,17 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.4.5",
+      "version": "13.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -12641,15 +12551,15 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "8.1.0",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^10.0.1"
+        "lru-cache": "^11.1.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
@@ -12685,7 +12595,7 @@
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12695,136 +12605,87 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "7.0.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^9.0.0"
+        "minimatch": "^10.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "7.0.2",
+      "version": "8.2.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/package-json": "^6.0.0",
-        "npm-package-arg": "^12.0.0",
-        "promzard": "^2.0.0",
-        "read": "^4.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^6.0.0"
+        "@npmcli/package-json": "^7.0.0",
+        "npm-package-arg": "^13.0.0",
+        "promzard": "^3.0.1",
+        "read": "^5.0.1",
+        "semver": "^7.7.2",
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "9.0.5",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
     },
-    "node_modules/npm/node_modules/ip-regex": {
+    "node_modules/npm/node_modules/is-cidr": {
+      "version": "6.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/isexe": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
@@ -12858,228 +12719,212 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "9.0.0",
+      "version": "10.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1"
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "7.0.1",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "binary-extensions": "^2.3.0",
-        "diff": "^5.1.0",
-        "minimatch": "^9.0.4",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0",
-        "tar": "^6.2.1"
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "binary-extensions": "^3.0.0",
+        "diff": "^8.0.2",
+        "minimatch": "^10.0.3",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "tar": "^7.5.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "9.0.1",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/run-script": "^9.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0",
-        "proc-log": "^5.0.0",
-        "read": "^4.0.0",
-        "read-package-json-fast": "^4.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "proc-log": "^6.0.0",
+        "read": "^5.0.1",
         "semver": "^7.3.7",
-        "walk-up-path": "^3.0.1"
+        "signal-exit": "^4.1.0",
+        "walk-up-path": "^4.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "6.0.1",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmhook": {
-      "version": "11.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
       "version": "8.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/run-script": "^9.0.1",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0"
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "9.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/run-script": "^10.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "10.0.1",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/package-json": "^7.0.0",
         "ci-info": "^4.0.0",
-        "normalize-package-data": "^7.0.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "proc-log": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0"
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "8.0.0",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^18.0.1"
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "7.0.0",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "7.0.0",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^6.0.1",
-        "@npmcli/run-script": "^9.0.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.4.3",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "14.0.3",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -13097,44 +12942,32 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "4.0.1",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "iconv-lite": "^0.7.2"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
@@ -13161,32 +12994,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "ISC"
     },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/minizlib": {
-      "version": "3.0.2",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13197,18 +13024,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
@@ -13216,16 +13031,25 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/negotiator": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "11.2.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13233,123 +13057,59 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.4.3",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-      "version": "7.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "8.1.0",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "6.0.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "7.1.1",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -13357,103 +13117,104 @@
         "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "13.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "10.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "11.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
       "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.1.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "9.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ignore-walk": "^7.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "10.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^7.1.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "11.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "18.0.2",
+      "version": "19.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/redact": "^3.0.0",
+        "@npmcli/redact": "^4.0.0",
         "jsonparse": "^1.3.1",
-        "make-fetch-happen": "^14.0.0",
+        "make-fetch-happen": "^15.0.0",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minizlib": "^3.0.1",
-        "npm-package-arg": "^12.0.0",
-        "proc-log": "^5.0.0"
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/p-map": {
-      "version": "7.0.3",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13464,84 +13225,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/npm/node_modules/pacote": {
-      "version": "19.0.1",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "@npmcli/run-script": "^9.0.0",
-        "cacache": "^19.0.0",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
         "fs-minipass": "^3.0.0",
         "minipass": "^7.0.2",
-        "npm-package-arg": "^12.0.0",
-        "npm-packlist": "^9.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0",
-        "tar": "^6.1.11"
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
       },
       "bin": {
         "pacote": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "4.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
         "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/path-key": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.11.1",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13554,21 +13300,21 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/proggy": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -13589,29 +13335,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
-      "version": "2.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^4.0.0"
+        "read": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -13623,46 +13356,24 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "4.1.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "^2.0.0"
+        "mute-stream": "^3.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -13673,7 +13384,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13682,27 +13393,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/signal-exit": {
@@ -13718,72 +13408,20 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "3.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "@sigstore/sign": "^3.1.0",
-        "@sigstore/tuf": "^3.1.0",
-        "@sigstore/verify": "^2.1.0"
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "make-fetch-happen": "^14.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/smart-buffer": {
@@ -13797,12 +13435,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.5",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -13824,26 +13462,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "dev": true,
@@ -13861,19 +13479,13 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.21",
+      "version": "3.0.23",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
-    "node_modules/npm/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/npm/node_modules/ssri": {
-      "version": "12.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13881,148 +13493,35 @@
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/supports-color": {
-      "version": "9.4.0",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.1",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/text-table": {
@@ -14032,19 +13531,19 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.14",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -14054,10 +13553,13 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
+      "version": "6.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -14068,7 +13570,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14089,54 +13591,26 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "3.0.1",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "3.0.1",
-        "debug": "^4.3.6",
-        "make-fetch-happen": "^14.0.1"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
-      "version": "3.0.1",
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
-      },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -14145,183 +13619,59 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "6.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "5.0.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/which/node_modules/isexe": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "6.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -15840,6 +15190,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/semantic-release/node_modules/@semantic-release/npm": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
+      "integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "execa": "^9.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash-es": "^4.17.21",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^8.0.0",
+        "npm": "^10.9.3",
+        "rc": "^1.2.8",
+        "read-pkg": "^9.0.0",
+        "registry-auth-token": "^5.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=20.1.0"
+      }
+    },
     "node_modules/semantic-release/node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -16038,6 +15415,171 @@
         "marked": ">=1 <16"
       }
     },
+    "node_modules/semantic-release/node_modules/normalize-url": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm": {
+      "version": "10.9.8",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.8.tgz",
+      "integrity": "sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==",
+      "bundleDependencies": [
+        "@isaacs/string-locale-compare",
+        "@npmcli/arborist",
+        "@npmcli/config",
+        "@npmcli/fs",
+        "@npmcli/map-workspaces",
+        "@npmcli/package-json",
+        "@npmcli/promise-spawn",
+        "@npmcli/redact",
+        "@npmcli/run-script",
+        "@sigstore/tuf",
+        "abbrev",
+        "archy",
+        "cacache",
+        "chalk",
+        "ci-info",
+        "cli-columns",
+        "fastest-levenshtein",
+        "fs-minipass",
+        "glob",
+        "graceful-fs",
+        "hosted-git-info",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-even-better-errors",
+        "libnpmaccess",
+        "libnpmdiff",
+        "libnpmexec",
+        "libnpmfund",
+        "libnpmhook",
+        "libnpmorg",
+        "libnpmpack",
+        "libnpmpublish",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpmversion",
+        "make-fetch-happen",
+        "minimatch",
+        "minipass",
+        "minipass-pipeline",
+        "ms",
+        "node-gyp",
+        "nopt",
+        "normalize-package-data",
+        "npm-audit-report",
+        "npm-install-checks",
+        "npm-package-arg",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "p-map",
+        "pacote",
+        "parse-conflict-json",
+        "proc-log",
+        "qrcode-terminal",
+        "read",
+        "semver",
+        "spdx-expression-parse",
+        "ssri",
+        "supports-color",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "treeverse",
+        "validate-npm-package-name",
+        "which",
+        "write-file-atomic"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/arborist": "^8.0.5",
+        "@npmcli/config": "^9.0.0",
+        "@npmcli/fs": "^4.0.0",
+        "@npmcli/map-workspaces": "^4.0.2",
+        "@npmcli/package-json": "^6.2.0",
+        "@npmcli/promise-spawn": "^8.0.3",
+        "@npmcli/redact": "^3.2.2",
+        "@npmcli/run-script": "^9.1.0",
+        "@sigstore/tuf": "^3.1.1",
+        "abbrev": "^3.0.1",
+        "archy": "~1.0.0",
+        "cacache": "^19.0.1",
+        "chalk": "^5.6.2",
+        "ci-info": "^4.4.0",
+        "cli-columns": "^4.0.0",
+        "fastest-levenshtein": "^1.0.16",
+        "fs-minipass": "^3.0.3",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "hosted-git-info": "^8.1.0",
+        "ini": "^5.0.0",
+        "init-package-json": "^7.0.2",
+        "is-cidr": "^5.1.1",
+        "json-parse-even-better-errors": "^4.0.0",
+        "libnpmaccess": "^9.0.0",
+        "libnpmdiff": "^7.0.5",
+        "libnpmexec": "^9.0.5",
+        "libnpmfund": "^6.0.5",
+        "libnpmhook": "^11.0.0",
+        "libnpmorg": "^7.0.0",
+        "libnpmpack": "^8.0.5",
+        "libnpmpublish": "^10.0.2",
+        "libnpmsearch": "^8.0.0",
+        "libnpmteam": "^7.0.0",
+        "libnpmversion": "^7.0.0",
+        "make-fetch-happen": "^14.0.3",
+        "minimatch": "^9.0.9",
+        "minipass": "^7.1.3",
+        "minipass-pipeline": "^1.2.4",
+        "ms": "^2.1.2",
+        "node-gyp": "^11.5.0",
+        "nopt": "^8.1.0",
+        "normalize-package-data": "^7.0.1",
+        "npm-audit-report": "^6.0.0",
+        "npm-install-checks": "^7.1.2",
+        "npm-package-arg": "^12.0.2",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-profile": "^11.0.1",
+        "npm-registry-fetch": "^18.0.2",
+        "npm-user-validate": "^3.0.0",
+        "p-map": "^7.0.4",
+        "pacote": "^19.0.1",
+        "parse-conflict-json": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "qrcode-terminal": "^0.12.0",
+        "read": "^4.1.0",
+        "semver": "^7.7.4",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^12.0.0",
+        "supports-color": "^9.4.0",
+        "tar": "^7.5.11",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "treeverse": "^3.0.0",
+        "validate-npm-package-name": "^6.0.2",
+        "which": "^5.0.0",
+        "write-file-atomic": "^6.0.0"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/semantic-release/node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -16053,6 +15595,2366 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/agent": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "8.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^4.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/metavuln-calculator": "^8.0.0",
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.1",
+        "@npmcli/query": "^4.0.0",
+        "@npmcli/redact": "^3.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "bin-links": "^5.0.0",
+        "cacache": "^19.0.1",
+        "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^8.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^10.2.2",
+        "minimatch": "^9.0.4",
+        "nopt": "^8.0.0",
+        "npm-install-checks": "^7.1.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.1",
+        "pacote": "^19.0.0",
+        "parse-conflict-json": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "proggy": "^3.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "promise-retry": "^2.0.1",
+        "read-package-json-fast": "^4.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^12.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^3.0.1"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/config": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/package-json": "^6.0.1",
+        "ci-info": "^4.0.0",
+        "ini": "^5.0.0",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "walk-up-path": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/git": {
+      "version": "6.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^8.0.0",
+        "ini": "^5.0.0",
+        "lru-cache": "^10.0.1",
+        "npm-pick-manifest": "^10.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "8.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^19.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "pacote": "^20.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
+      "version": "20.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^6.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/run-script": "^9.0.0",
+        "cacache": "^19.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^12.0.0",
+        "npm-packlist": "^9.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0",
+        "tar": "^7.5.10"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "6.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^6.0.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^8.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.5.3",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "8.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "which": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/query": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "3.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "node-gyp": "^11.0.0",
+        "proc-log": "^5.0.0",
+        "which": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@sigstore/bundle": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.4.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@sigstore/core": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+      "version": "0.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "make-fetch-happen": "^14.0.2",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.4.1",
+        "tuf-js": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@sigstore/verify": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/@tufjs/canonical-json": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/abbrev": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/agent-base": {
+      "version": "7.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/aproba": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/bin-links": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^7.0.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "read-cmd-shim": "^5.0.0",
+        "write-file-atomic": "^6.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cacache": {
+      "version": "19.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^4.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/chalk": {
+      "version": "5.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/chownr": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ci-info": {
+      "version": "4.4.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cidr-regex": {
+      "version": "4.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cli-columns": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cmd-shim": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/cssesc": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/diff": {
+      "version": "5.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/encoding": {
+      "version": "0.1.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/err-code": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/foreground-child": {
+      "version": "3.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/glob": {
+      "version": "10.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/hosted-git-info": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ignore-walk": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ini": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/init-package-json": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/package-json": "^6.0.0",
+        "npm-package-arg": "^12.0.0",
+        "promzard": "^2.0.0",
+        "read": "^4.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "^6.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ip-address": {
+      "version": "10.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ip-regex": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-cidr": {
+      "version": "5.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/just-diff": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/just-diff-apply": {
+      "version": "5.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmaccess": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^12.0.0",
+        "npm-registry-fetch": "^18.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmdiff": {
+      "version": "7.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^8.0.5",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "binary-extensions": "^2.3.0",
+        "diff": "^5.1.0",
+        "minimatch": "^9.0.4",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0",
+        "tar": "^7.5.11"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmexec": {
+      "version": "9.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^8.0.5",
+        "@npmcli/run-script": "^9.0.1",
+        "ci-info": "^4.0.0",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0",
+        "proc-log": "^5.0.0",
+        "read": "^4.0.0",
+        "read-package-json-fast": "^4.0.0",
+        "semver": "^7.3.7",
+        "walk-up-path": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmfund": {
+      "version": "6.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^8.0.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmhook": {
+      "version": "11.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^18.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmorg": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^18.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmpack": {
+      "version": "8.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^8.0.5",
+        "@npmcli/run-script": "^9.0.1",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmpublish": {
+      "version": "10.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ci-info": "^4.0.0",
+        "normalize-package-data": "^7.0.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-registry-fetch": "^18.0.1",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.7",
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmsearch": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^18.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmteam": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^18.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/libnpmversion": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^6.0.1",
+        "@npmcli/run-script": "^9.0.1",
+        "json-parse-even-better-errors": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "14.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^4.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^12.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minimatch": {
+      "version": "9.0.9",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass": {
+      "version": "7.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-fetch": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minipass-sized/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/minizlib": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/negotiator": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/node-gyp": {
+      "version": "11.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.4.3",
+        "tinyglobby": "^0.2.12",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/nopt": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/normalize-package-data": {
+      "version": "7.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^8.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-audit-report": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-bundled": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-install-checks": {
+      "version": "7.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-package-arg": {
+      "version": "12.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^6.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-packlist": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "10.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^7.1.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "npm-package-arg": "^12.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-profile": {
+      "version": "11.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "18.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/redact": "^3.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^14.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^4.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^12.0.0",
+        "proc-log": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/npm-user-validate": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/p-map": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/pacote": {
+      "version": "19.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^6.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/run-script": "^9.0.0",
+        "cacache": "^19.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^12.0.0",
+        "npm-packlist": "^9.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0",
+        "tar": "^7.5.10"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/parse-conflict-json": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^4.0.0",
+        "just-diff": "^6.0.0",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/picomatch": {
+      "version": "4.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/proc-log": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/proggy": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-call-limit": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promise-retry": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/promzard": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/read-package-json-fast": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/retry": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/semver": {
+      "version": "7.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/sigstore": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "@sigstore/sign": "^3.1.0",
+        "@sigstore/tuf": "^3.1.0",
+        "@sigstore/verify": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/socks": {
+      "version": "2.8.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/ssri": {
+      "version": "12.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/supports-color": {
+      "version": "9.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tar": {
+      "version": "7.5.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/treeverse": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tuf-js": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "3.0.1",
+        "debug": "^4.4.1",
+        "make-fetch-happen": "^14.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^9.0.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/unique-filename": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/unique-slug": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/walk-up-path": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/which": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/which/node_modules/isexe": {
+      "version": "3.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/write-file-atomic": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm/node_modules/yallist": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/semantic-release/node_modules/p-reduce": {
@@ -16970,6 +18872,18 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -17550,6 +19464,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.6",
-    "@semantic-release/npm": "^12.0.0",
+    "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.1",
     "@types/clean-css": "^4.2.11",
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
I'll start by understanding the repo's CI setup and how publishing currently works.
This publishes to npm via `npx semantic-release` (using `@semantic-release/npm`) in the `release` job. Trusted publishing replaces long-lived npm tokens with OIDC. Let me verify exactly what npm's trusted publishers supports and requires for CircleCI before changing anything.
CircleCI is supported (since April 2026). Let me get the exact CircleCI config recipe and the semantic-release specifics.
Let me confirm which `@semantic-release/npm` version added OIDC support, since the repo pins `^12.0.0` and the ENONPMTOKEN error is thrown by that plugin's token check.
Let me check the installed `@semantic-release/npm` version and its README for OIDC handling.
Important: `@semantic-release/npm@12.0.2` bundles `npm@^10.9.3`, but OIDC requires npm ≥ 11.5.1. The plugin runs publish via its bundled npm, so simply upgrading the Docker image's npm may not be enough. Let me confirm how the plugin resolves npm and which plugin version bundles a compatible npm.
`@semantic-release/npm@13.1.0` introduced OIDC trusted publishing (latest 13.1.5). The repo pins `^12.0.0`, which is why OIDC won't work today. I need to bump to v13. Let me verify peer-dep compatibility with the installed `semantic-release@24` and the bundled npm version in v13.
v13 is fully compatible: peer `semantic-release >=20.1.0` (have 24.2.9), bundles `npm@^11.6.2` (satisfies the ≥11.5.1 OIDC requirement), and engines `^22.14.0` matches the repo's node 22.17.0. The plugin publishes with its *bundled* npm, so bumping the plugin — not the image's npm — is the real fix.

Let me check local tooling before regenerating the lockfile.
Local node 22.22.1 works. Now let me make the changes. First, bump the plugin version:
Now update the lockfile:
The lockfile now resolves `13.1.5` with bundled `npm@^11.6.2`. Let me verify the lockfile is internally consistent (root dep spec + resolved tarball + nested npm version):
Bundled npm hoists to `11.18.0` (≥11.5.1) — OIDC-capable. Now the CircleCI config. Let me confirm the exact `circleci` CLI command syntax before editing, since a typo would break the release pipeline.
Confirmed — context is optional for token retrieval. Now updating the `release` job:
Now let me install deps and run the project's tests + format check (both are CI gates):
All 121 tests pass, build and prettier checks are green (the ts-jest warnings are pre-existing config noise, unrelated to this change). Let me verify the final `release` job:
Done. Here's what I found and changed.

## What the task needed

Skier publishes to npm from CircleCI's `release` job via `npx semantic-release` (the `@semantic-release/npm` plugin). "Trusted publishers" replaces the long-lived `NPM_TOKEN` with short-lived, per-publish credentials minted through OIDC — CircleCI proves the job's identity to npm, npm hands back a token good for that one publish. James has already set up the trust relationship on the npm side; this PR makes CircleCI actually use it.

Two things were needed, and only doing one would have left the pipeline broken:

1. **The CI config** has to mint the OIDC token and hand it to npm.
2. **The tooling has to be new enough.** OIDC publishing requires npm CLI ≥ 11.5.1, and — critically — `@semantic-release/npm` publishes with its *own bundled* npm, not the image's npm. The pinned `^12.0.0` bundles npm 10.x and has no OIDC support at all, so it would keep throwing `ENONPMTOKEN No npm token specified` no matter what the CI config did (this is exactly semantic-release/npm issue #1069). OIDC support landed in `@semantic-release/npm` v13.1.0.

## What I changed

- **`package.json` + `package-lock.json`:** bumped `@semantic-release/npm` `^12.0.0` → `^13.1.5`. v13 bundles npm `11.18.0` (≥ 11.5.1 ✓), detects `NPM_ID_TOKEN` and switches to trusted publishing automatically, and its peer requirement (`semantic-release >=20.1.0`) and engines (`node ^22.14.0`) are both satisfied by the repo's existing `semantic-release@24.2.9` and node `22.17.0`. No other dependency churn.
- **`.circleci/config.yml`:** in the `release` job, wrapped `npx semantic-release` in a step that first exchanges CircleCI's OIDC token for a publish token, per CircleCI's official recipe:
  ```
  export NPM_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')"
  npx semantic-release
  ```
  With `NPM_ID_TOKEN` set, no `NPM_TOKEN` is read.

## Testing evidence

- `npm run build` (tsc) — clean.
- `npm test` — **121 passed, 18 suites, 0 failed.** (The `ts-jest` `TS151002` warnings are pre-existing config noise, not related to this change.)
- `npm run format:check` (prettier) — clean.

I could not exercise the OIDC exchange itself locally — `circleci run oidc get` only works inside a CircleCI cloud job, so the actual token mint is validated on the first `main` build after merge.

## What I deliberately did not do

- **Did not change the Docker image or node version.** The image's system npm (10.x) is irrelevant because the plugin publishes with its bundled 11.18.0, and node 22.17.0 already satisfies v13's engines. Leaving the image pinned avoids unrelated churn.
- **Did not add a CircleCI `context:` to the job.** Contexts are an optional hardening layer for trusted publishing, not required to obtain the token — see DECISIONS.
- **Did not remove the `NPM_TOKEN` project env var** from CircleCI settings (it's on the CircleCI side, not in this repo, and is now simply unused). Safe to delete once the first OIDC publish is confirmed green.
- Did not touch any secrets, `.env`, or the Firebase deploy jobs.
- Note: CircleCI trusted publishing does **not** produce provenance attestations (only GitHub Actions / GitLab do), so publishing continues without provenance — no change from today.

SUMMARY: Enabled npm trusted publishing (OIDC) for skier by bumping `@semantic-release/npm` to v13 and having the CircleCI release job mint an `NPM_ID_TOKEN` instead of using a long-lived npm token.

DECISIONS:
- **Does your npm trusted-publisher config restrict to a specific CircleCI context?** When you set up trusted publishing on npmjs.com you can optionally scope it to a named CircleCI context in addition to org+project. I've configured the minimal org+project form (no context), which works if you left the context field blank. If you *did* pin a context on the npm side, the publish will fail the trust match until I add a matching `context: [<name>]` to the `release` job in the workflow — tell me the context name and I'll add it. Recommendation: leave it as-is unless you explicitly set a context on npm.

---
_Opened by Tom from Slack._