### PR TITLE
Task B5 of approved spec jarvis-memory/specs/skier/docs-site-revamp

### DIFF
--- a/docs/markdown-frontmatter.md
+++ b/docs/markdown-frontmatter.md
@@ -245,6 +245,16 @@ error** — a broken include never silently renders nothing. `@include` lines
 inside a fenced code block are left untouched, so this page can show the syntax
 without transcluding itself.
 
+### Live example
+
+This page dogfoods the directive. The code block below is not hand-written — it
+is transcluded at build time from the `snippet-error` region of Skier's own
+renderer, `src/utils/markdown.ts`, which is covered by the renderer test suite.
+If that class changes or moves, this docs build fails, so the example here can
+never drift from the shipping code:
+
+@include src/utils/markdown.ts region="snippet-error"
+
 ---
 
 ## Heading Anchors & Table of Contents

--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -441,3 +441,20 @@ describe('snippet transclusion (renderMarkdown @include)', () => {
     );
   });
 });
+
+describe('snippet transclusion (docs dogfood)', () => {
+  // The transclusion docs page (`docs/markdown-frontmatter.md`) includes the
+  // real `snippet-error` region of this renderer. This test guards that link:
+  // if the region marker is renamed, moved, or removed, the docs example would
+  // silently rot — here it fails loudly instead.
+  const repoRoot = path.resolve(__dirname, '..', '..');
+
+  it('resolves the region the docs page transcludes from real source', async () => {
+    const html = await renderMarkdown('@include src/utils/markdown.ts region="snippet-error"', {
+      includeBaseDir: repoRoot,
+    });
+    const plain = html.replace(/<[^>]+>/g, '');
+    expect(plain).toContain('class SnippetIncludeError extends Error');
+    expect(plain).not.toContain('#region');
+  });
+});

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -212,12 +212,14 @@ const calloutExtension: TokenizerAndRendererExtension = {
  * Paths are resolved relative to the render base dir (the project working
  * directory by default; see `renderMarkdown` options).
  */
+// #region snippet-error
 export class SnippetIncludeError extends Error {
   constructor(message: string) {
     super(`[skier] snippet include: ${message}`);
     this.name = 'SnippetIncludeError';
   }
 }
+// #endregion snippet-error
 
 export interface IncludeDirective {
   path: string;


### PR DESCRIPTION
I'll start by investigating the actual state of the repo — the prior run claimed the feature was already merged, but I should verify that myself before concluding anything.
Interesting — the log now shows commits #39 and #40 beyond what the prior run saw. Let me examine the actual state of the transclusion code.
The feature and tests are indeed present on main. But the task has a specific requirement the prior run explicitly punted: "document the directive on a docs page **that itself uses it**." Let me check whether any docs page actually transcludes real source, versus just documenting the syntax as literal text.
Now I understand the real gap. The renderer and tests are complete and merged, but **no docs page actually uses `@include`** — the "Snippet transclusion" section only shows the syntax as literal text inside fenced blocks. The task explicitly requires "document the directive on a docs page **that itself uses it**." That's the unmet piece. Let me check how the docs build resolves include paths before I wire up a real transclusion.
Let me read the spec's B5 section to make sure I match its exact intent for the "docs page that uses it" requirement.
The spec itself is outside my worktree, but the task description is explicit: "document the directive on a docs page that itself uses it." Let me review the existing tests to match their shape and avoid duplicating coverage.
Renderer coverage is already thorough. The real remaining B5 work is the dogfood requirement: no docs page actually *uses* `@include`. Let me look at the test setup style and the top of the docs page before making changes.
I now have the full picture. The renderer, unit tests, and integration tests for `@include` are all complete and merged. The one genuinely unmet requirement is the dogfood: **no docs page actually uses the directive.** The transclusion section only shows the syntax as literal text. I'll wire the docs page to transclude a real, tested source snippet — Skier's own `@include` implementation documenting itself — which is the strongest possible proof that examples can't drift.

Let me make the changes.
Now the docs page — add a live example that actually transcludes that region at build time:
Now a test guarding the dogfood link, so a rename/move of the region breaks the suite (not just the docs build). I'll add it in the same shape, resolving against the real repo root:
Now build, run tests, do the docs build to confirm the page transcludes the real snippet, and check formatting:
Dependencies aren't installed in this worktree. Let me install them.
All 122 tests pass (121 before + my new dogfood guard). Now confirm the actual docs build renders the transcluded snippet, and check formatting:
The token is span-wrapped by highlight.js, so let me confirm the class content is actually present in the rendered block:
The page now genuinely transcludes the real, tested source at build time. Final gate — prettier check:
Let me confirm the `public/` build output is gitignored so I'm not adding build artifacts to the PR:
All green. Build output is gitignored, so my diff is exactly three files: the region markers in the renderer source, the live `@include` in the docs page, and the guard test.

---

## Task B5 — snippet transclusion: made the docs page actually *use* the directive (dogfooded)

### What I found

The `@include` **renderer** was already implemented, tested, and merged on `main` (it landed at or before the B2 copy-code merge, `ef55357`). `src/utils/markdown.ts` carries the full directive — whole-file, `region="…"`, `lines="a-b"`, `lang=`/`title=` overrides, quoted paths, a dedicated `SnippetIncludeError` that fails the build loudly, and the `parseIncludeDirective`/`extractRegion`/`extractLines` helpers — wired in as a preprocessing stage in `renderMarkdownWithHeadings` before `marked.parse`. The unit + integration tests in `markdown.test.ts` cover all of it. I verified this directly rather than trusting the earlier run's report.

So re-implementing the renderer would only produce a no-op diff. **But one requirement of the task was genuinely unmet:** *"document the directive on a docs page that itself uses it."* The docs page only showed the syntax as literal text inside fenced blocks — **no page anywhere actually transcluded a real file.** The previous run acknowledged this and deferred it to A3; but "a docs page that itself uses it" is the dogfood proof B5 is supposed to deliver, so I did it here.

### What I changed

1. **`src/utils/markdown.ts`** — wrapped the `SnippetIncludeError` class in `// #region snippet-error` / `// #endregion snippet-error` markers (using the feature's own region mechanism — no new machinery).
2. **`docs/markdown-frontmatter.md`** — added a **"Live example"** subsection under *Snippet transclusion* that transcludes that region: `@include src/utils/markdown.ts region="snippet-error"`. The rendered page now pulls Skier's own `@include` implementation into the docs about `@include`, at build time. The tightest possible demonstration of "examples cannot drift from the working code": if that class is renamed or moved, the docs build fails.
3. **`src/utils/markdown.test.ts`** — added a `snippet transclusion (docs dogfood)` test that renders that exact directive against the real repo root and asserts the class body is present with the `#region` markers stripped. This guards the docs link at the test level too, so region rot fails the suite, not just the build.

### Verification (all green, exercised for real)

- **`npm run build`** (tsc) — clean, exit 0.
- **`npm test`** — **122 passed / 18 suites** (121 before + the new dogfood guard).
- **`npm run docs:build`** — exit 0. Confirmed the rendered `public/markdown-frontmatter.html` contains the real class body inside a `data-filename="src/utils/markdown.ts"` code block, with the `#region` markers stripped, while the literal syntax examples above it stay literal (fenced blocks correctly not self-included).
- **`npm run format:check`** (CI prettier gate) — clean.

### What I deliberately did not do

- **Did not re-implement or refactor the existing, tested renderer** — that would be churn with a merge-conflict risk against B1/B4 and no benefit.
- **Did not convert the task-reference / API-reference pages to `@include`.** Those pages are A3's, and pointing the reference examples at `src/builtins/*` is a larger content decision that belongs with whoever owns that IA. This task's requirement was one docs page that uses the directive; that is now satisfied, and A3 can follow the established pattern for the rest.
- **Did not touch git/gh or anything outside the worktree.** Build output (`/public`, `dist/`) is gitignored, so the diff is exactly the three files above.

SUMMARY: Verified Skier's `@include` renderer was already implemented and tested on main, then satisfied B5's remaining requirement by making the transclusion docs page dogfood the directive — transcluding Skier's own tested `SnippetIncludeError` source at build time — with a guard test (122/122 green).

---
_Opened by Tom from Slack._