### PR TITLE
Build task and API reference docs from source of truth

### DIFF
--- a/docs/api-reference/config-interfaces.md
+++ b/docs/api-reference/config-interfaces.md
@@ -1,0 +1,131 @@
+---
+title: Config Interfaces
+section: API Reference
+order: 3
+---
+
+# Config Interfaces
+
+The exported configuration type for every built-in task, in one place. Each
+factory takes exactly the object shown here. Every block is transcluded from the
+task's own source, so it's always in step with the shipping code — for the full
+option-by-option prose, follow the link to the task's
+[Task Reference](../task-reference/index.md) page.
+
+```ts
+import type {
+  PrepareOutputConfig,
+  SetGlobalsConfig,
+  SetGlobalFromMarkdownConfig,
+  GeneratePagesConfig,
+  GenerateItemsConfig,
+  GeneratePaginatedItemsConfig,
+  GenerateFeedConfig,
+  GenerateSitemapConfig,
+  GenerateSearchIndexConfig,
+  GenerateNavDataConfig,
+  BundleCssConfig,
+  CopyStaticConfig,
+} from 'skier';
+```
+
+---
+
+## Setup
+
+### PrepareOutputConfig
+
+For [`prepareOutputTask`](../task-reference/prepareOutputTask.md):
+
+@include src/builtins/prepareOutputTask/index.ts region="config"
+
+---
+
+## Globals
+
+### SetGlobalsConfig
+
+For [`setGlobalsTask`](../task-reference/setGlobalsTask.md):
+
+@include src/builtins/setGlobalsTask/index.ts region="config"
+
+### SetGlobalFromMarkdownConfig
+
+For [`setGlobalFromMarkdownTask`](../task-reference/setGlobalFromMarkdownTask.md):
+
+@include src/builtins/setGlobalFromMarkdownTask/index.ts region="config"
+
+---
+
+## Content
+
+### GeneratePagesConfig
+
+For [`generatePagesTask`](../task-reference/generatePagesTask.md):
+
+@include src/builtins/generatePagesTask/index.ts region="config"
+
+### GenerateItemsConfig
+
+For [`generateItemsTask`](../task-reference/generateItemsTask.md):
+
+@include src/builtins/generateItemsTask/index.ts region="config"
+
+### GeneratePaginatedItemsConfig
+
+For [`generatePaginatedItemsTask`](../task-reference/generatePaginatedItemsTask.md):
+
+@include src/builtins/generatePaginatedItemsTask/index.ts region="config"
+
+---
+
+## Feeds & SEO
+
+### GenerateFeedConfig
+
+For [`generateFeedTask`](../task-reference/generateFeedTask.md):
+
+@include src/builtins/generateFeedTask/index.ts region="config"
+
+### GenerateSitemapConfig
+
+For [`generateSitemapTask`](../task-reference/generateSitemapTask.md):
+
+@include src/builtins/generateSitemapTask/index.ts region="config"
+
+### GenerateSearchIndexConfig
+
+For [`generateSearchIndexTask`](../task-reference/generateSearchIndexTask.md):
+
+@include src/builtins/generateSearchIndexTask/index.ts region="config"
+
+### GenerateNavDataConfig
+
+For [`generateNavDataTask`](../task-reference/generateNavDataTask.md):
+
+@include src/builtins/generateNavDataTask/index.ts region="config"
+
+---
+
+## Assets
+
+### BundleCssConfig
+
+For [`bundleCssTask`](../task-reference/bundleCssTask.md):
+
+@include src/builtins/bundleCssTask/index.ts region="config"
+
+### CopyStaticConfig
+
+For [`copyStaticTask`](../task-reference/copyStaticTask.md):
+
+@include src/builtins/copyStaticTask/index.ts region="config"
+
+---
+
+## Related
+
+- [Task Contract](./task-contract.md) — the `TaskDef` these factories return.
+- [Core Types](./core-types.md) — the data types configs reference (`SkierItem`,
+  `SkierGlobals`, and produced types).
+- [Task Reference](../task-reference/index.md) — full per-task documentation.

--- a/docs/api-reference/core-types.md
+++ b/docs/api-reference/core-types.md
@@ -1,0 +1,93 @@
+---
+title: Core Types
+section: API Reference
+order: 2
+---
+
+# Core Types
+
+The data that flows through a Skier pipeline. `SkierItem` and `SkierGlobals` are
+the two types you'll touch most; below them are the structured outputs the
+built-in tasks produce and hand to your templates.
+
+All signatures are transcluded from source at build time.
+
+---
+
+## SkierItem
+
+Every piece of itemised content — a blog post, a portfolio entry, any Markdown
+file processed by [`generateItemsTask`](../task-reference/generateItemsTask.md) —
+is normalised into a `SkierItem`. It's what lands in the `outputVar` array in
+globals, and what [`generateFeedTask`](../task-reference/generateFeedTask.md)
+consumes as its `articles`:
+
+@include src/types.ts region="SkierItem"
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `section` | string? | Content group (e.g. `posts`), from the item's subdirectory. Absent under `flatStructure`. |
+| `itemName` | string | Filename without extension — the slug. |
+| `itemPath` | string | Source path of the item file. |
+| `outPath` | string | Path the rendered HTML was written to. |
+| `type` | string | Source type — `'md'`, `'html'`, etc. |
+| `relativePath` | string? | Output path relative to `outDir`. |
+| `title` | string | Resolved title (frontmatter → filename). |
+| `link` | string | Root-relative URL of the item. |
+| `body` | string | Rendered HTML body. |
+| `date` / `dateObj` / `dateDisplay` | string? / Date? / string? | Parsed date in three forms, when available. |
+| `excerpt` | string? | Short summary, when extracted. |
+
+> To add your own fields, extend `SkierItem` in your project — it's an ordinary
+> interface. Custom template variables per item come from `additionalVarsFn`
+> (see [generateItemsTask](../task-reference/generateItemsTask.md#template-variables)).
+
+---
+
+## SkierGlobals
+
+The shared bag of build-wide data. Each task's `run()` return value is merged in,
+and the whole object is exposed to every template:
+
+@include src/types.ts region="SkierGlobals"
+
+It's deliberately open (`[key: string]: unknown`) — any task can contribute any
+key. See the [Task Contract](./task-contract.md#the-run-contract) for how data
+gets in and out.
+
+---
+
+## Produced data types
+
+Some built-ins produce structured objects for your templates rather than plain
+strings. These are the shapes they emit.
+
+### NavData
+
+[`generateNavDataTask`](../task-reference/generateNavDataTask.md) builds a full
+sidebar/navigation tree from your docs' frontmatter and exposes it on globals:
+
+@include src/builtins/generateNavDataTask/index.ts region="navtypes"
+
+### PaginationMeta
+
+[`generatePaginatedItemsTask`](../task-reference/generatePaginatedItemsTask.md)
+passes a `PaginationMeta` object to each page template so it can render page
+numbers and prev/next links:
+
+@include src/builtins/generatePaginatedItemsTask/index.ts region="pagination-meta"
+
+### SearchIndex
+
+[`generateSearchIndexTask`](../task-reference/generateSearchIndexTask.md) writes
+a JSON document in this shape for a client-side search UI to consume:
+
+@include src/builtins/generateSearchIndexTask/index.ts region="searchtypes"
+
+---
+
+## Related
+
+- [Task Contract](./task-contract.md) — `TaskDef`, `TaskContext`, `Logger`.
+- [Config Interfaces](./config-interfaces.md) — the `*Config` type for each
+  built-in task.

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -6,30 +6,68 @@ order: 0
 
 # API Reference
 
-> **Status: stubbed.** This section is part of the planned docs information
-> architecture, but its content lands in a later task (see the docs-site revamp
-> spec). This page exists so the **API Reference** sidebar section renders and so
-> the frontmatter conventions are in place for the pages that will fill it.
+Skier's programmatic surface — the types you import and the contract you
+implement when you write `skier.tasks.mjs` or author a custom task. Everything
+documented here is exported from the package root:
 
-The API Reference will document Skier's programmatic surface — the pieces you
-import and call when you write `skier.tasks.mjs` or author a custom task:
+```ts
+import {
+  // built-in task factories
+  prepareOutputTask,
+  generateItemsTask,
+  // …and their config + output types
+} from 'skier';
 
-- **The task contract** — `TaskDef`, `TaskContext`, and how `run()` receives
-  config and returns globals.
-- **Core types** — `SkierItem`, `SkierGlobals`, `NavData` / `NavSection` /
-  `NavItem`, `Heading`, and the frontmatter shapes.
-- **Config interfaces per built-in** — the exported `*Config` types (e.g.
-  `GenerateItemsConfig`, `GenerateNavDataConfig`).
-- **Utilities** — the markdown renderer, link-rewriting, and path helpers
-  exposed for custom tasks.
+import type {
+  TaskDef,
+  TaskContext,
+  Logger,
+  SkierItem,
+  SkierGlobals,
+} from 'skier';
+```
 
-### In the meantime
+Every code block in this section is **transcluded from the real source at build
+time** (via [`@include`](../markdown-frontmatter.md#snippet-transclusion-include)),
+so the signatures here are always exactly what the package ships — they cannot
+drift.
 
-- Per-task usage and options live in the [Task Reference](/task-reference).
-- Writing your own task is covered in the
-  [Custom Tasks](/custom-tasks) guide.
-- The end-to-end pipeline model is in [Architecture](/architecture).
+---
 
-<!-- New API Reference pages: add `section: API Reference` frontmatter and an
-     `order`. See the "Docs site navigation" conventions in
-     docs/markdown-frontmatter.md before adding pages here. -->
+## What's here
+
+| Page | Covers |
+|------|--------|
+| [Task Contract](./task-contract.md) | `TaskDef`, `TaskContext`, `Logger` — the shape every task implements and the config-in / globals-out contract `run()` follows. This is the custom-task authoring API. |
+| [Core Types](./core-types.md) | `SkierItem` and `SkierGlobals` (the data that flows through a pipeline), plus the structured data built-in tasks produce: `NavData`, `PaginationMeta`, `SearchIndex`. |
+| [Config Interfaces](./config-interfaces.md) | The exported `*Config` type for every built-in task, in one place, each linking to its full [Task Reference](../task-reference/index.md) page. |
+
+---
+
+## How the pieces fit
+
+```mermaid
+flowchart LR
+    Config[*Config] -->|passed to| Factory[task factory]
+    Factory -->|returns| TaskDef
+    TaskDef -->|run config, ctx| Output
+    Output -->|merged into| Globals[SkierGlobals]
+    Globals -->|read by| Next[next task's run]
+```
+
+A **task factory** (e.g. `generateItemsTask`) takes a `*Config` object and
+returns a [`TaskDef`](./task-contract.md#taskdef). Skier runs each `TaskDef`'s
+[`run()`](./task-contract.md#the-run-contract) in order, passing the config and a
+shared [`TaskContext`](./task-contract.md#taskcontext); whatever `run()` returns
+is merged into [`SkierGlobals`](./core-types.md#skierglobals) for later tasks and
+templates to read.
+
+---
+
+## Related
+
+- [Custom Tasks](../custom-tasks.md) — the how-to guide for writing tasks (this
+  section is the reference for the types that guide uses).
+- [Task Reference](../task-reference/index.md) — per-task usage, options, and
+  examples for every built-in.
+- [Architecture](../architecture.md) — the end-to-end pipeline model.

--- a/docs/api-reference/task-contract.md
+++ b/docs/api-reference/task-contract.md
@@ -1,0 +1,149 @@
+---
+title: Task Contract
+section: API Reference
+order: 1
+---
+
+# Task Contract
+
+Everything Skier runs — every [built-in](../task-reference/index.md) and every
+[custom task](../custom-tasks.md) — is a `TaskDef`. This page is the reference
+for that contract: the shape you implement, the context you're handed, and the
+config-in / globals-out rule `run()` follows.
+
+The signatures below are transcluded straight from `src/types.ts`, so they are
+exactly what the package exports.
+
+---
+
+## TaskDef
+
+A task is a plain object with a `name`, its `config`, and an async `run`
+function. It's generic over its config and output types:
+
+@include src/types.ts region="TaskDef"
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| `name` | string | ✅ | Unique identifier. Used in logs and by the CLI's `--only` / `--skip` filters. |
+| `title` | string | | Human-readable description shown while the task runs. |
+| `config` | `Config` | ✅ | Your task's configuration object. Passed back to `run` as its first argument. |
+| `run` | function | ✅ | The work. Receives `config` and a [`TaskContext`](#taskcontext); returns a promise of the data to merge into globals. |
+
+Built-in tasks are **factories** that build a `TaskDef` for you from a config
+object — you rarely construct one by hand. For example, the whole of
+`copyStaticTask` is a real, tested `TaskDef` factory:
+
+@include src/builtins/copyStaticTask/index.ts region="config"
+
+@include src/builtins/copyStaticTask/index.ts region="factory"
+
+---
+
+## The `run()` contract
+
+`run` is where a task does its work. It's called once, with two arguments:
+
+- **`config`** — the config object the task was created with (typed as `Config`).
+- **`ctx`** — a [`TaskContext`](#taskcontext): the shared globals, a logger, and
+  the debug flag.
+
+**Whatever `run` returns is shallow-merged into the shared globals.** That is the
+only channel between tasks — a task reads earlier tasks' output from
+`ctx.globals` and contributes its own by returning an object:
+
+```js
+const collectPostsTask = {
+  name: 'collect-posts',
+  config: {},
+  run: async (config, ctx) => {
+    ctx.logger.info('Collecting posts…');
+    return { posts: ['Post 1', 'Post 2'] }; // merged into globals.posts
+  },
+};
+
+const usePostsTask = {
+  name: 'use-posts',
+  config: {},
+  run: async (config, ctx) => {
+    ctx.logger.info(`Found ${ctx.globals.posts.length} posts`);
+    // Returning nothing (undefined) contributes nothing to globals — fine.
+  },
+};
+```
+
+Return an object to add to globals; return nothing to contribute nothing. Read
+existing data from `ctx.globals`, don't mutate it — return new data instead.
+See [Custom Tasks → The Context Object](../custom-tasks.md#the-context-object)
+for the full authoring walkthrough.
+
+---
+
+## TaskContext
+
+Every `run` call receives the same shared context:
+
+@include src/types.ts region="TaskContext"
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `globals` | [`SkierGlobals`](./core-types.md#skierglobals) | Shared key-value data accumulated from every prior task's return value. |
+| `logger` | [`Logger`](#logger) | Structured, level-based logging. Prefer this over `console.log`. |
+| `debug` | boolean | `true` when the build was run with `--debug`. Gate verbose logging on it. |
+
+---
+
+## Logger
+
+The logger is a small, level-based interface. `debug` output is only surfaced
+when the build runs with `--debug`:
+
+@include src/types.ts region="Logger"
+
+```js
+run: async (config, ctx) => {
+  ctx.logger.debug('Verbose detail, only shown with --debug');
+  ctx.logger.info('Normal progress');
+  ctx.logger.warn('Something looks off, continuing anyway');
+  ctx.logger.error('Something failed');
+};
+```
+
+---
+
+## Typing a custom task
+
+In TypeScript, import the contract from the package root and let the generics
+carry your config and output shapes:
+
+```ts
+import type { TaskDef, TaskContext, SkierGlobals } from 'skier';
+
+interface GreetConfig {
+  name: string;
+}
+
+export const greetTask = (config: GreetConfig): TaskDef<GreetConfig, SkierGlobals> => ({
+  name: 'greet',
+  title: `Greet ${config.name}`,
+  config,
+  run: async (cfg, ctx: TaskContext) => {
+    ctx.logger.info(`Hello, ${cfg.name}!`);
+    return { greeted: cfg.name };
+  },
+});
+```
+
+In plain JavaScript you don't import anything — a task is just an object with
+`name`, `config`, and `run`.
+
+---
+
+## Related
+
+- [Core Types](./core-types.md) — `SkierItem`, `SkierGlobals`, and the data
+  built-in tasks produce.
+- [Config Interfaces](./config-interfaces.md) — the `*Config` type for each
+  built-in.
+- [Custom Tasks](../custom-tasks.md) — the how-to guide, with patterns and
+  testing.

--- a/docs/custom-tasks.md
+++ b/docs/custom-tasks.md
@@ -12,16 +12,12 @@ Extend Skier with your own build steps. This guide covers everything from basic 
 
 ## Task Structure
 
-A task is an object with three properties:
+A task is a `TaskDef` — an object with a `name`, its `config`, and an async
+`run` function. This is the real exported type, transcluded from source:
 
-```typescript
-interface Task {
-  name: string;                         // Unique identifier
-  title?: string;                       // Human-readable description
-  config?: Record<string, any>;         // Your task's configuration
-  run: (config, context) => Promise<Record<string, any> | void>;
-}
-```
+@include src/types.ts region="TaskDef"
+
+> Full contract reference: [API Reference → Task Contract](./api-reference/task-contract.md).
 
 The `run` function receives:
 - **`config`** — Your task's configuration object
@@ -280,14 +276,14 @@ Full type definitions for custom tasks:
 
 ```typescript
 // tasks/myTask.ts
-import type { Task, TaskContext, TaskConfig } from 'skier';
+import type { TaskDef, TaskContext } from 'skier';
 
-interface MyTaskConfig extends TaskConfig {
+interface MyTaskConfig {
   prefix: string;
   maxItems?: number;
 }
 
-export const myTask = (options: MyTaskConfig): Task => ({
+export const myTask = (options: MyTaskConfig): TaskDef<MyTaskConfig> => ({
   name: 'my-task',
   config: options,
   run: async (config: MyTaskConfig, ctx: TaskContext) => {

--- a/docs/task-reference/bundleCssTask.md
+++ b/docs/task-reference/bundleCssTask.md
@@ -51,6 +51,16 @@ bundleCssTask({
 
 ---
 
+## Type signature
+
+The exact `BundleCssConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/bundleCssTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## File Order
 
 Files are concatenated in **alphabetical order**. Control ordering with filename prefixes:

--- a/docs/task-reference/copyStaticTask.md
+++ b/docs/task-reference/copyStaticTask.md
@@ -47,6 +47,16 @@ copyStaticTask({
 
 ---
 
+## Type signature
+
+The exact `CopyStaticConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/copyStaticTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Directory Preservation
 
 The entire directory structure is preserved:

--- a/docs/task-reference/generateFeedTask.md
+++ b/docs/task-reference/generateFeedTask.md
@@ -74,6 +74,16 @@ generateFeedTask({
 
 ---
 
+## Type signature
+
+The exact `GenerateFeedConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/generateFeedTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Article Format
 
 Each article needs these fields:

--- a/docs/task-reference/generateItemsTask.md
+++ b/docs/task-reference/generateItemsTask.md
@@ -63,6 +63,16 @@ generateItemsTask({
 
 ---
 
+## Type signature
+
+The exact `GenerateItemsConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/generateItemsTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Sorting Items
 
 Default: items are sorted by `date` (newest first).

--- a/docs/task-reference/generateNavDataTask.md
+++ b/docs/task-reference/generateNavDataTask.md
@@ -52,6 +52,16 @@ generateNavDataTask({
 
 ---
 
+## Type signature
+
+The exact `GenerateNavDataConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/generateNavDataTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Metadata Extraction
 
 The task reads Markdown files and extracts:
@@ -82,25 +92,12 @@ order: 1
 
 ## Output Structure
 
-```typescript
-interface NavData {
-  sections: NavSection[];  // Ordered sections for sidebar
-  pages: NavItem[];        // Flat list for prev/next navigation
-}
+The task sets `globals[outputVar]` to a `NavData` object. These are the real
+exported types, transcluded from source so they never drift from the code:
 
-interface NavSection {
-  name: string;            // Section display name
-  order: number;           // Sort order
-  items: NavItem[];        // Direct items (no subcategory)
-  children?: NavSection[]; // Nested subcategory groups
-}
+@include src/builtins/generateNavDataTask/index.ts region="navtypes"
 
-interface NavItem {
-  title: string;           // Page display title
-  url: string;             // Page URL path
-  order: number;           // Sort order
-}
-```
+> Also documented in the [API Reference → Core Types](../api-reference/core-types.md#navdata).
 
 ---
 

--- a/docs/task-reference/generatePagesTask.md
+++ b/docs/task-reference/generatePagesTask.md
@@ -51,6 +51,16 @@ generatePagesTask({
 
 ---
 
+## Type signature
+
+The exact `GeneratePagesConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/generatePagesTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Directory Structure
 
 Templates mirror output structure:

--- a/docs/task-reference/generatePaginatedItemsTask.md
+++ b/docs/task-reference/generatePaginatedItemsTask.md
@@ -70,6 +70,16 @@ public/
 
 ---
 
+## Type signature
+
+The exact `GeneratePaginatedItemsConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/generatePaginatedItemsTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Data Sources
 
 **From pipeline globals (recommended):**

--- a/docs/task-reference/generateSearchIndexTask.md
+++ b/docs/task-reference/generateSearchIndexTask.md
@@ -1,5 +1,6 @@
 ---
 title: generateSearchIndexTask
+section: Task Reference
 subcategory: Feeds & SEO
 order: 3
 ---
@@ -56,6 +57,16 @@ generateSearchIndexTask({
 
 ---
 
+## Type signature
+
+The exact `GenerateSearchIndexConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/generateSearchIndexTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## What Gets Indexed
 
 For each page the task extracts:
@@ -76,27 +87,14 @@ repeated on every page.
 
 ## Output Structure
 
-```typescript
-interface SearchIndex {
-  pages: SearchIndexEntry[]; // sorted by URL for deterministic output
-}
+The real exported types, transcluded from source so this reference can't drift
+from the shipping contract:
 
-interface SearchIndexEntry {
-  url: string;               // clean page URL
-  title: string;             // page title
-  headings: SearchHeading[]; // headings in document order
-  body: string;              // plain, searchable text
-}
-
-interface SearchHeading {
-  text: string;              // heading text, HTML stripped
-  level: number;             // 1–6
-  id?: string;               // anchor slug for deep-linking, when present
-}
-```
+@include src/builtins/generateSearchIndexTask/index.ts region="searchtypes"
 
 This format is a **stable contract** consumed by the client-side search UI. Fields are added
-additively; existing fields are not renamed or repurposed.
+additively; existing fields are not renamed or repurposed. It's also documented in the
+[API Reference → Core Types](../api-reference/core-types.md#searchindex).
 
 Example entry:
 

--- a/docs/task-reference/generateSitemapTask.md
+++ b/docs/task-reference/generateSitemapTask.md
@@ -47,6 +47,16 @@ generateSitemapTask({
 
 ---
 
+## Type signature
+
+The exact `GenerateSitemapConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/generateSitemapTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## URL Cleaning
 
 All URLs are automatically cleaned for best SEO practice:

--- a/docs/task-reference/prepareOutputTask.md
+++ b/docs/task-reference/prepareOutputTask.md
@@ -35,6 +35,16 @@ prepareOutputTask({ outDir: 'public' })
 
 ---
 
+## Type signature
+
+The exact `PrepareOutputConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/prepareOutputTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Why It's Important
 
 Without this task:

--- a/docs/task-reference/setGlobalFromMarkdownTask.md
+++ b/docs/task-reference/setGlobalFromMarkdownTask.md
@@ -47,6 +47,16 @@ setGlobalFromMarkdownTask({
 
 ---
 
+## Type signature
+
+The exact `SetGlobalFromMarkdownConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/setGlobalFromMarkdownTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Using in Templates
 
 ```handlebars

--- a/docs/task-reference/setGlobalsTask.md
+++ b/docs/task-reference/setGlobalsTask.md
@@ -47,6 +47,16 @@ setGlobalsTask({
 
 ---
 
+## Type signature
+
+The exact `SetGlobalsConfig` interface, transcluded from source so it stays in step with the shipping code:
+
+@include src/builtins/setGlobalsTask/index.ts region="config"
+
+> Every task's config type together: [API Reference → Config Interfaces](../api-reference/config-interfaces.md).
+
+---
+
 ## Static Values
 
 Simple key-value assignment:

--- a/src/builtins/bundleCssTask/index.ts
+++ b/src/builtins/bundleCssTask/index.ts
@@ -4,12 +4,14 @@ import { extname, join } from '../../utils/pathHelpers.js';
 import { throwTaskError } from '../../utils/errors.js';
 import CleanCSS from 'clean-css';
 
+// #region config
 export interface BundleCssConfig {
   from: string; // source directory
   to: string; // output directory
   output: string; // output filename (e.g. styles.min.css)
   minify?: boolean;
 }
+// #endregion config
 
 export function bundleCssTask(config: BundleCssConfig): TaskDef<BundleCssConfig> {
   return {

--- a/src/builtins/copyStaticTask/index.ts
+++ b/src/builtins/copyStaticTask/index.ts
@@ -2,11 +2,14 @@ import { TaskDef } from '../../types.js';
 import { ensureDir, copyDir } from '../../utils/fileHelpers.js';
 import { throwTaskError } from '../../utils/errors.js';
 
+// #region config
 export interface CopyStaticConfig {
   from: string;
   to: string;
 }
+// #endregion config
 
+// #region factory
 export function copyStaticTask(config: CopyStaticConfig): TaskDef<CopyStaticConfig> {
   return {
     name: 'copy-static',
@@ -30,3 +33,4 @@ export function copyStaticTask(config: CopyStaticConfig): TaskDef<CopyStaticConf
     },
   };
 }
+// #endregion factory

--- a/src/builtins/generateFeedTask/index.ts
+++ b/src/builtins/generateFeedTask/index.ts
@@ -3,6 +3,7 @@ import { ensureDir, writeFileUtf8 } from '../../utils/fileHelpers.js';
 import { join } from '../../utils/pathHelpers.js';
 import type { SkierItem, TaskDef } from '../../types.js';
 
+// #region config
 export interface GenerateFeedConfig {
   articles: SkierItem[];
   outDir: string;
@@ -25,6 +26,7 @@ export interface GenerateFeedConfig {
     };
   };
 }
+// #endregion config
 
 export function generateFeedTask(
   config: GenerateFeedConfig,

--- a/src/builtins/generateItemsTask/index.ts
+++ b/src/builtins/generateItemsTask/index.ts
@@ -75,6 +75,7 @@ export interface ItemFunctionArgs {
   fileStat: import('fs-extra').Stats;
 }
 
+// #region config
 export interface GenerateItemsConfig {
   /** Directory containing markdown/HTML items */
   itemsDir: string;
@@ -113,6 +114,7 @@ export interface GenerateItemsConfig {
     args: ItemisedRenderVars,
   ) => Record<string, unknown> | Promise<Record<string, unknown>>;
 }
+// #endregion config
 
 /**
  * Parses simple YAML frontmatter from markdown content.

--- a/src/builtins/generateNavDataTask/index.ts
+++ b/src/builtins/generateNavDataTask/index.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import type { TaskDef, TaskContext, SkierGlobals } from '../../types.js';
 
+// #region navtypes
 /**
  * A navigation item representing a single page in the sidebar.
  */
@@ -39,7 +40,9 @@ export interface NavData {
   /** Flat list of all pages for prev/next navigation */
   pages: NavItem[];
 }
+// #endregion navtypes
 
+// #region config
 export interface GenerateNavDataConfig {
   /** Directory containing documentation files to scan */
   docsDir: string;
@@ -56,6 +59,7 @@ export interface GenerateNavDataConfig {
   /** Subcategory ordering configuration (for nested groups within sections) */
   subcategoryOrder?: Record<string, number>;
 }
+// #endregion config
 
 interface ParsedFrontmatter {
   title?: string;

--- a/src/builtins/generatePagesTask/index.ts
+++ b/src/builtins/generatePagesTask/index.ts
@@ -29,6 +29,7 @@ export interface HtmlRenderVars extends Record<string, unknown> {
   currentPagePath: string;
 }
 
+// #region config
 export interface GeneratePagesConfig {
   pagesDir: string;
   partialsDir: string;
@@ -45,6 +46,7 @@ export interface GeneratePagesConfig {
     args: HtmlRenderVars,
   ) => Record<string, unknown> | Promise<Record<string, unknown>>;
 }
+// #endregion config
 
 /**
  * Built-in HTML generation task for Skier: supports partials, variables, and per-page metadata.

--- a/src/builtins/generatePaginatedItemsTask/index.ts
+++ b/src/builtins/generatePaginatedItemsTask/index.ts
@@ -4,6 +4,7 @@ import type { TaskDef } from '../../types.js';
 import { throwTaskError } from '../../utils/errors.js';
 import { setupHandlebarsEnvironment } from '../../utils/handlebars.js';
 
+// #region pagination-meta
 /**
  * Pagination metadata object exposed to templates.
  */
@@ -35,10 +36,12 @@ export interface PaginationMeta {
     isCurrent: boolean;
   }>;
 }
+// #endregion pagination-meta
 
 /**
  * Configuration for generatePaginatedItemsTask.
  */
+// #region config
 export interface GeneratePaginatedItemsConfig {
   /**
    * Path to a JSON file containing the data.
@@ -107,6 +110,7 @@ export interface GeneratePaginatedItemsConfig {
     items: unknown[];
   }) => Record<string, unknown> | Promise<Record<string, unknown>>;
 }
+// #endregion config
 
 /**
  * Splits an array into chunks of the specified size.

--- a/src/builtins/generateSearchIndexTask/index.ts
+++ b/src/builtins/generateSearchIndexTask/index.ts
@@ -11,6 +11,7 @@ import { throwTaskError, validateRequiredConfig } from '../../utils/errors.js';
 /** Default glob patterns excluded from the search index (kept in step with the sitemap task). */
 const DEFAULT_EXCLUDES = ['404.html', '404/**'];
 
+// #region searchtypes
 /**
  * A single heading extracted from a page, in document order.
  *
@@ -53,7 +54,9 @@ export interface SearchIndex {
   /** All indexed pages, sorted by URL for deterministic output */
   pages: SearchIndexEntry[];
 }
+// #endregion searchtypes
 
+// #region config
 export interface GenerateSearchIndexConfig {
   /** Directory to scan for rendered `.html` pages */
   scanDir: string;
@@ -78,6 +81,7 @@ export interface GenerateSearchIndexConfig {
   /** Pretty-print the JSON (default: `false` — compact output keeps the payload lean). */
   pretty?: boolean;
 }
+// #endregion config
 
 /**
  * Test whether a relative path matches a simple glob pattern.

--- a/src/builtins/generateSitemapTask/index.ts
+++ b/src/builtins/generateSitemapTask/index.ts
@@ -6,6 +6,7 @@ import { throwTaskError, validateRequiredConfig } from '../../utils/errors.js';
 /** Default glob patterns excluded from the sitemap */
 const DEFAULT_EXCLUDES = ['404.html', '404/**'];
 
+// #region config
 export interface GenerateSitemapConfig {
   /** Directory to scan for .html files */
   scanDir: string;
@@ -16,6 +17,7 @@ export interface GenerateSitemapConfig {
   /** (Optional) glob patterns to exclude from sitemap. Merged with defaults (404.html, 404/**). */
   excludes?: string[];
 }
+// #endregion config
 
 /**
  * Test whether a relative path matches a simple glob pattern.

--- a/src/builtins/prepareOutputTask/index.ts
+++ b/src/builtins/prepareOutputTask/index.ts
@@ -1,9 +1,11 @@
 import { pathExists, removeDir, ensureDir } from '../../utils/fileHelpers.js';
 import { TaskDef } from '../../types.js';
 
+// #region config
 export interface PrepareOutputConfig {
   outDir: string;
 }
+// #endregion config
 
 export function prepareOutputTask(config: PrepareOutputConfig): TaskDef<PrepareOutputConfig> {
   return {

--- a/src/builtins/setGlobalFromMarkdownTask/index.ts
+++ b/src/builtins/setGlobalFromMarkdownTask/index.ts
@@ -2,10 +2,12 @@ import { readFileUtf8 } from '../../utils/fileHelpers.js';
 import { marked } from 'marked';
 import type { TaskDef } from '../../types.js';
 
+// #region config
 export interface SetGlobalFromMarkdownConfig {
   mdPath: string; // Path to markdown file
   outputVar: string; // Variable name for output HTML
 }
+// #endregion config
 
 /**
  * Reads a markdown file, converts to HTML, and outputs it as a variable for downstream tasks.

--- a/src/builtins/setGlobalsTask/index.ts
+++ b/src/builtins/setGlobalsTask/index.ts
@@ -1,9 +1,11 @@
 import type { TaskDef, TaskContext, SkierGlobals } from '../../types.js';
 
+// #region config
 export interface SetGlobalsConfig {
   values?: SkierGlobals;
   valuesFn?: (globals: SkierGlobals) => SkierGlobals | Promise<SkierGlobals>;
 }
+// #endregion config
 
 /**
  * Adds arbitrary key-value pairs to the Skier globals context for downstream use in templates and tasks.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,35 @@
+import type { TaskDef, TaskContext, Logger, SkierItem, SkierGlobals } from './index.js';
+
+// Guards the package's public *type* surface. The core task-authoring contract
+// (TaskDef, TaskContext, Logger, SkierItem, SkierGlobals) is documented in
+// docs/api-reference as importable from the package root, and custom tasks are
+// typed against it. These are compile-time-only imports: if src/index.ts stops
+// re-exporting them from './types.js', this file fails to compile (TS2305) and
+// the suite goes red — so the docs can't silently drift from the real exports.
+describe('package public type surface', () => {
+  it('re-exports the core task-authoring contract from the package root', () => {
+    const item: SkierItem = {
+      itemName: 'hello-world',
+      itemPath: 'src/items/hello-world.md',
+      outPath: 'public/hello-world/index.html',
+      type: 'md',
+      title: 'Hello World',
+      link: '/hello-world/',
+      body: '<p>Hi</p>',
+    };
+
+    const task: TaskDef<{ greeting: string }, SkierGlobals> = {
+      name: 'greet',
+      title: 'Greet the world',
+      config: { greeting: 'hello' },
+      run: async (config, ctx: TaskContext) => {
+        const logger: Logger = ctx.logger;
+        logger.info(`${config.greeting}, ${item.title}`);
+        return { greeted: item.itemName };
+      },
+    };
+
+    expect(task.name).toBe('greet');
+    expect(task.config.greeting).toBe('hello');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,8 @@ export * from './builtins/generatePaginatedItemsTask/index.js';
 export * from './builtins/generateNavDataTask/index.js';
 export * from './builtins/generateSearchIndexTask/index.js';
 // Add any new built-ins here as needed
+
+// Core task-authoring contract: TaskDef, TaskContext, Logger, SkierItem,
+// SkierGlobals. Surfaced from the package root so custom tasks can be typed with
+// `import type { TaskDef, TaskContext } from 'skier'` (see docs/api-reference).
+export * from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 // Shared type for all itemised content in Skier pipelines
 
+// #region SkierItem
 export interface SkierItem {
   section?: string;
   itemName: string;
@@ -16,27 +17,36 @@ export interface SkierItem {
   excerpt?: string;
   // If you want to extend with custom fields, extend this interface in your own project.
 }
+// #endregion SkierItem
 
+// #region SkierGlobals
 export interface SkierGlobals {
   [key: string]: unknown;
 }
+// #endregion SkierGlobals
 
+// #region Logger
 export interface Logger {
   info(msg: string): void;
   warn(msg: string): void;
   error(msg: string): void;
   debug(msg: string): void;
 }
+// #endregion Logger
 
+// #region TaskContext
 export interface TaskContext {
   logger: Logger;
   debug: boolean;
   globals: SkierGlobals;
 }
+// #endregion TaskContext
 
+// #region TaskDef
 export interface TaskDef<Config = unknown, Output = unknown> {
   name: string;
   title?: string;
   config: Config;
   run: (config: Config, ctx: TaskContext) => Promise<Output>;
 }
+// #endregion TaskDef


### PR DESCRIPTION
I'll start by exploring the current state of the repo — the docs IA from A1, the source of truth in `src/types.ts` and `src/builtins/`, and the `@include` directive from B5.
I'll read the source of truth and the A1 IA conventions in parallel.
Now let me look at the A1 IA conventions — the `task-reference` and `api-reference` directories — and the B5 `@include` implementation.
The task-reference pages already exist. I need to understand their current state — are they complete, or stubs that A1 scaffolded? Let me read the index files and a representative sample.
The 12 task pages already exist and are detailed (hand-written, not yet dogfooding `@include`). The **API Reference is explicitly stubbed** — the `TaskDef`/`TaskContext` contract page doesn't exist yet. Let me understand the `@include` mechanics and how the docs build resolves paths before I plan the work.
`@include` paths resolve from `process.cwd()` (repo root during docs build), so `@include src/builtins/...` works. Now let me map every builtin's real config interface and exports so I can wire `@include` precisely, while I read the frontmatter conventions and a couple of builtin sources.
I'll explore the structure and read all the relevant files in parallel.
Now let me read all 12 index.ts files in parallel.
Now the remaining 6 tasks.
Let me confirm there are no `#region` markers anywhere in the builtins.
Let me read the built-in source files directly to see how the `Config` interfaces sit in each file, plus a few more existing task pages to match their structure.
The `Config` interfaces sit cleanly at the top of each file — ideal for `@include`. Important find: `src/index.ts` re-exports the builtins but **not** `src/types.ts`, yet `custom-tasks.md` tells users to `import type { Task, TaskContext, TaskConfig } from 'skier'` — names that don't exist (real names are `TaskDef`/`TaskContext`, no `TaskConfig`). Let me confirm the package's actual export surface.
No `#region` markers exist in any of the 12 built-in task files (the only hits are in `src/utils/markdown.ts`, the include-directive parser itself, and its test). Let me confirm whether `src/index.ts` also re-exports `src/types.ts`.
Here is the complete, precise map. All line numbers are 1-indexed and inclusive. No `// #region` / `// #endregion` markers exist in any of the 12 built-in task files (the only `#region` occurrences in the repo are in `src/utils/markdown.ts` and `src/utils/markdown.test.ts`).

# Per-task breakdown

## 1. copyStaticTask
- index.ts: `src/builtins/copyStaticTask/index.ts`
- Config: `CopyStaticConfig` — lines 5-8
- Factory: line 10 — `export function copyStaticTask(config: CopyStaticConfig): TaskDef<CopyStaticConfig> {`
- Other exported types: none
- Region markers: none

## 2. bundleCssTask
- index.ts: `src/builtins/bundleCssTask/index.ts`
- Config: `BundleCssConfig` — lines 7-12
- Factory: line 14 — `export function bundleCssTask(config: BundleCssConfig): TaskDef<BundleCssConfig> {`
- Other exported types: none
- Region markers: none

## 3. generateSitemapTask
- index.ts: `src/builtins/generateSitemapTask/index.ts`
- Config: `GenerateSitemapConfig` — lines 9-18
- Factory: lines 68-70 — `export function generateSitemapTask(\n  config: GenerateSitemapConfig,\n): TaskDef<GenerateSitemapConfig, Record<string, never>> {`
- Other exported types: none (`matchesGlob`, `cleanUrl`, `DEFAULT_EXCLUDES` are module-private)
- Region markers: none

## 4. generatePagesTask
- index.ts: `src/builtins/generatePagesTask/index.ts`
- Config: `GeneratePagesConfig` — lines 32-47
- Factory: lines 53-55 — `export function generatePagesTask(\n  config: GeneratePagesConfig,\n): TaskDef<GeneratePagesConfig, Record<string, never>> {`
- Other exported types: `HtmlRenderVars` (extends `Record<string, unknown>`) — lines 25-30
- Region markers: none
- Note: `HtmlRenderVars` is exported from this file but is NOT named in `src/builtins/index.ts` (only reaches consumers via the `export *` in `src/index.ts`).

## 5. generateItemsTask
- index.ts: `src/builtins/generateItemsTask/index.ts`
- Config: `GenerateItemsConfig` — lines 78-115
- Factory: lines 165-167 — `export function generateItemsTask(\n  config: GenerateItemsConfig,\n): TaskDef<GenerateItemsConfig, Record<string, SkierItem[]>> {`
- Other exported types (in file order):
  - `FrontmatterData` — lines 15-20
  - `ItemisedRenderVars` (extends `Record<string, unknown>`) — lines 25-54
  - `LinkRewriteConfig` — lines 59-65
  - `ItemFunctionArgs` — lines 70-76
- Region markers: none
- Note: none of these four extra types are named in `src/builtins/index.ts`; they reach consumers only via `export *` in `src/index.ts`. Module-private helpers: `parseSimpleFrontmatter`, `extractDateFromFrontmatter`, `extractDateFromFilename`.

## 6. prepareOutputTask
- index.ts: `src/builtins/prepareOutputTask/index.ts`
- Config: `PrepareOutputConfig` — lines 4-6
- Factory: line 8 — `export function prepareOutputTask(config: PrepareOutputConfig): TaskDef<PrepareOutputConfig> {`
- Other exported types: none
- Region markers: none

## 7. generateFeedTask
- index.ts: `src/builtins/generateFeedTask/index.ts`
- Config: `GenerateFeedConfig` — lines 6-27
- Factory: lines 29-31 — `export function generateFeedTask(\n  config: GenerateFeedConfig,\n): TaskDef<GenerateFeedConfig, { rssPath: string; jsonPath: string; atomPath: string }> {`
- Other exported types: none
- Region markers: none

## 8. setGlobalFromMarkdownTask
- index.ts: `src/builtins/setGlobalFromMarkdownTask/index.ts`
- Config: `SetGlobalFromMarkdownConfig` — lines 5-8
- Factory: lines 14-16 — `export function setGlobalFromMarkdownTask(\n  config: SetGlobalFromMarkdownConfig,\n): TaskDef<SetGlobalFromMarkdownConfig, { [outputVar: string]: string }> {`
- Other exported types: none
- Region markers: none

## 9. setGlobalsTask
- index.ts: `src/builtins/setGlobalsTask/index.ts`
- Config: `SetGlobalsConfig` — lines 3-6
- Factory: line 14 — `export function setGlobalsTask(config: SetGlobalsConfig): TaskDef<SetGlobalsConfig, SkierGlobals> {`
- Other exported types: none
- Region markers: none

## 10. generatePaginatedItemsTask
- index.ts: `src/builtins/generatePaginatedItemsTask/index.ts`
- Config: `GeneratePaginatedItemsConfig` — lines 42-109
- Factory: lines 186-188 — `export function generatePaginatedItemsTask(\n  config: GeneratePaginatedItemsConfig,\n): TaskDef<GeneratePaginatedItemsConfig, Record<string, never>> {`
- Other exported types: `PaginationMeta` — lines 10-37
- Region markers: none
- Module-private helpers: `chunk`, `getPageUrl`, `getOutputPath`, `buildPaginationMeta`.

## 11. generateNavDataTask
- index.ts: `src/builtins/generateNavDataTask/index.ts`
- Config: `GenerateNavDataConfig` — lines 43-58
- Factory: lines 127-129 — `export function generateNavDataTask(\n  config: GenerateNavDataConfig,\n): TaskDef<GenerateNavDataConfig, SkierGlobals> {`
- Other exported types (in file order):
  - `NavItem` — lines 8-17
  - `NavSection` — lines 22-31
  - `NavData` — lines 36-41
- Region markers: none
- Note: `ParsedFrontmatter` (lines 60-66) is NOT exported (module-private). Also a local `interface ScannedItem` sits inside the run function (lines 148-152), non-exported.

## 12. generateSearchIndexTask
- index.ts: `src/builtins/generateSearchIndexTask/index.ts`
- Config: `GenerateSearchIndexConfig` — lines 57-80
- Factory: lines 223-225 — `export function generateSearchIndexTask(\n  config: GenerateSearchIndexConfig,\n): TaskDef<GenerateSearchIndexConfig, SkierGlobals> {`
- Other exported types (in file order):
  - `SearchHeading` — lines 21-28
  - `SearchIndexEntry` — lines 34-43
  - `SearchIndex` — lines 52-55
- Region markers: none
- Module-private helpers: `matchesGlob`, `cleanUrl`, `decodeEntities`, `htmlToText`, `extractRegion`, `cleanRegion`, `extractHeadings`, `extractTitle`, plus consts `DEFAULT_EXCLUDES`, `NAMED_ENTITIES`.

---

# Aggregator / type files (confirmed)

## `src/builtins/index.ts` (33 lines, exports-only barrel)
```
1  // skier built-in task factories (exports only)
2  export { copyStaticTask, CopyStaticConfig } from './copyStaticTask/index.js';
3  export { bundleCssTask, BundleCssConfig } from './bundleCssTask/index.js';
4  export { generateSitemapTask, GenerateSitemapConfig } from './generateSitemapTask/index.js';
5  export { generatePagesTask, GeneratePagesConfig } from './generatePagesTask/index.js';
6  export { generateItemsTask, GenerateItemsConfig } from './generateItemsTask/index.js';
7  export { prepareOutputTask, PrepareOutputConfig } from './prepareOutputTask/index.js';
8  export { generateFeedTask, GenerateFeedConfig } from './generateFeedTask/index.js';
9  export {
10   setGlobalFromMarkdownTask,
11   SetGlobalFromMarkdownConfig,
12 } from './setGlobalFromMarkdownTask/index.js';
13 export { setGlobalsTask, SetGlobalsConfig } from './setGlobalsTask/index.js';
14 export {
15   generatePaginatedItemsTask,
16   GeneratePaginatedItemsConfig,
17   PaginationMeta,
18 } from './generatePaginatedItemsTask/index.js';
19 export {
20   generateNavDataTask,
21   GenerateNavDataConfig,
22   NavData,
23   NavSection,
24   NavItem,
25 } from './generateNavDataTask/index.js';
26 export {
27   generateSearchIndexTask,
28   GenerateSearchIndexConfig,
29   SearchIndex,
30   SearchIndexEntry,
31   SearchHeading,
32 } from './generateSearchIndexTask/index.js';
```
This barrel re-exports each factory + its `*Config`, plus the named auxiliary types (`PaginationMeta`; `NavData`/`NavSection`/`NavItem`; `SearchIndex`/`SearchIndexEntry`/`SearchHeading`). It does NOT list `HtmlRenderVars`, `FrontmatterData`, `ItemisedRenderVars`, `LinkRewriteConfig`, or `ItemFunctionArgs`.

## `src/types.ts` (43 lines)
- `SkierItem` — lines 3-18
- `SkierGlobals` — lines 20-22
- `Logger` — lines 24-29
- `TaskContext` — lines 31-35
- `TaskDef<Config = unknown, Output = unknown>` — lines 37-42

## `src/index.ts` (14 lines) — re-export status
```
1  export * from './builtins/prepareOutputTask/index.js';
2  export * from './builtins/bundleCssTask/index.js';
3  export * from './builtins/copyStaticTask/index.js';
4  export * from './builtins/setGlobalFromMarkdownTask/index.js';
5  export * from './builtins/setGlobalsTask/index.js';
6  export * from './builtins/generateItemsTask/index.js';
7  export * from './builtins/generateFeedTask/index.js';
8  export * from './builtins/generatePagesTask/index.js';
9  export * from './builtins/generateSitemapTask/index.js';
10 export * from './builtins/generatePaginatedItemsTask/index.js';
11 export * from './builtins/generateNavDataTask/index.js';
12 export * from './builtins/generateSearchIndexTask/index.js';
13 // Add any new built-ins here as needed
```
Key points:
- `src/index.ts` uses `export *` directly from each task's `index.ts` (NOT via `src/builtins/index.ts`), so it DOES re-export every task's `*Config`, every factory, and every exported auxiliary type — including the ones the barrel omits (`HtmlRenderVars`, `FrontmatterData`, `ItemisedRenderVars`, `LinkRewriteConfig`, `ItemFunctionArgs`), as well as `PaginationMeta`, `NavData`/`NavSection`/`NavItem`, and `SearchIndex`/`SearchIndexEntry`/`SearchHeading`.
- `src/index.ts` does NOT re-export `src/types.ts`. The shared types `SkierItem`, `SkierGlobals`, `Logger`, `TaskContext`, `TaskDef` are therefore not surfaced through the package root here (they are only imported internally by task files).
Confirmed: `src/index.ts` does **not** re-export `src/types.ts`, so `TaskDef`/`TaskContext` are not part of the package's public type surface — yet the docs tell users to import them. That's a real correctness gap the reference must resolve. Let me verify how the docs build passes `includeBaseDir` and read the remaining task pages while the Explore agent maps line ranges.
I have a complete map. Confirmed: `generateItemsTask` renders docs with the default `includeBaseDir` (= `process.cwd()` = repo root during `docs:build`), so `@include src/...` resolves correctly. Now let me read the remaining built-in sources so I can place `#region` markers precisely and write accurate reference prose.
Let me read the remaining four larger built-ins to place region markers precisely and write accurate prose.
Now the two remaining large ones — `generateNavDataTask` and `generateSearchIndexTask` config + auxiliary types, and `generatePaginatedItemsTask`.
I now have the full picture. Let me execute. First, add `#region config` markers around each built-in's `Config` interface. Starting with the simple single-config files.
Now the four with auxiliary types — `generatePagesTask`, `generateItemsTask`, `generatePaginatedItemsTask`, plus the config for nav/search.
Now add region markers to `src/types.ts` and export the core contract types from `src/index.ts` (the dogfooding gap — the docs tell users to import these, but the package didn't surface them).
Now a guard test that locks the type export in place (compile-time via ts-jest). Let me check the existing test style first.
No `isolatedModules`, so ts-jest and `tsc` both fully type-check — a missing export breaks compilation. Let me write the guard test.
Now the API Reference. Let me replace the stub `index.md` and create the three contract pages, dogfooding `@include` from the real source throughout.
The `lines="10-32"` include in task-contract.md is now wrong (the region markers shifted line numbers) — and line-based includes are the fragile pattern I'm avoiding. Let me add a clean `factory` region to `copyStaticTask` and reference that instead.
Now `core-types.md` documents the produced-data types too. Let me add clean regions around those public output types, then write the page.
Now write `core-types.md`:
Now `config-interfaces.md` — every built-in's `Config` type in one place, each pulled from source and linked to its task page:
Now wire `@include` into the 12 task-reference pages. Let me read the 8 I haven't seen so I can insert the type-signature block precisely.
Let me read the remaining 5 task pages, then insert a "Type signature" `@include` block after each Configuration section.
Two things stand out in the existing A1 pages: `generateSearchIndexTask.md` is **missing `section: Task Reference`** in frontmatter (it'd fall into a stray nav group), and `generateNavDataTask.md`/`generateSearchIndexTask.md` have **hand-copied interface code blocks that have already drifted** (the nav page's `NavItem` omits the real `active?` field). I'll fix the frontmatter, replace those hand-copied blocks with `@include`, and add a "Type signature" `@include` to each task page. Starting with the frontmatter fix and the two drift replacements:
Now insert a "Type signature" `@include` section into each of the 12 task pages, placed right after their Configuration section:
Now fix the `custom-tasks.md` guide, which currently tells users to `import type { Task, TaskContext, TaskConfig } from 'skier'` — types that don't exist. My new reference now contradicts it, so I'll align it to the real `TaskDef` contract and dogfood the real type via `@include`.
Now let me build, test, and run the docs build to verify all the `@include` directives resolve. First check whether dependencies are installed.
Build is clean. Now the test suite:
All 123 tests pass (19 suites — my guard test added the 19th). The ts-jest warnings are pre-existing. Now the docs build, which exercises every `@include`:
Build exits 0 — every `@include` resolved (a broken one throws and fails the build). Let me verify the rendered output actually contains the transcluded source and that `#region` markers were stripped.
The `#region` "leaks" are only in `markdown-frontmatter.html` — and those are the *intentional literal syntax examples* inside fenced code blocks (B5's own docs), not transclusion output. My includes stripped the markers correctly. The literal-string grep missed the code because highlight.js splits it into spans. Let me verify precisely via the filename attributes and token content.
All transclusions resolved correctly and the `NavItem.active?` drift is now fixed. Let me confirm every task page rendered its include and that the prettier CI gate passes.
Everything is green. Let me confirm the build artifacts are gitignored so my diff is only source, docs, and the test.
Everything verified — `/public` and `dist/` are gitignored, so the diff is exactly source, docs, and the guard test. All gates pass: `tsc` clean, 123/123 tests, `docs:build` exit 0 (every `@include` resolved), prettier clean.

---

## Task A3 — Reference docs: per-task pages + the custom-task authoring API, dogfooding `@include`

Spec: `jarvis-memory/specs/skier/docs-site-revamp.md` (Task A3). Repo: `Ripixel-Studio/skier`.

### What I found (state on latest main)

A1 (IA) and B5 (`@include`) are both merged. On top of them:

- **The 12 per-task reference pages already existed** under `docs/task-reference/` (detailed, hand-written) — but **none used `@include`**; every code block was hand-copied and free to drift.
- **The API Reference was an explicit stub** (`docs/api-reference/index.md` said "content lands in a later task"). The custom-task authoring contract — `TaskDef` / `TaskContext` — was **undocumented**.
- **A real correctness gap, surfaced by writing the reference:** the docs told users to `import type { Task, TaskContext, TaskConfig } from 'skier'` (in `custom-tasks.md`), but those names **don't exist** — the real types are `TaskDef` / `TaskContext`, and `src/index.ts` **didn't re-export `src/types.ts` at all**, so the core contract wasn't in the package's public surface. The documented import would fail.
- Two hand-copied interface blocks had **already drifted**: `generateNavDataTask.md`'s `NavItem` was missing the real `active?` field, and `generateSearchIndexTask.md` duplicated the search types by hand.
- `generateSearchIndexTask.md` was **missing `section: Task Reference`** frontmatter, so it would fall into a stray nav group (violating A1's conventions).

### What I changed and why

**API Reference — built out (the headline deliverable), fully dogfooding `@include`:**
- `api-reference/index.md` — rewrote the stub into a real overview of the programmatic surface.
- `api-reference/task-contract.md` — the custom-task authoring API: `TaskDef`, `TaskContext`, `Logger`, and the config-in / globals-out `run()` contract. Types transcluded from `src/types.ts`; `copyStaticTask` shown as a real, tested `TaskDef` factory via `@include`.
- `api-reference/core-types.md` — `SkierItem`, `SkierGlobals`, and the produced-data contracts `NavData` / `PaginationMeta` / `SearchIndex`, each transcluded from source.
- `api-reference/config-interfaces.md` — every built-in's `*Config`, transcluded and cross-linked to its task page.

**Task Reference — wired `@include` into all 12 pages:** each gained a "Type signature" section transcluding its real `*Config` interface (complementing, not replacing, the readable option tables), and a link back to the API Reference. Replaced the two drifted hand-copied interface blocks (nav/search "Output Structure") with `@include` of the real source, and fixed the missing `section:` frontmatter.

**`custom-tasks.md`** — corrected the fictional `import { Task, TaskConfig }` to the real `import type { TaskDef, TaskContext } from 'skier'`, and transcluded the real `TaskDef` in place of the hand-written illustration.

**Package source (to make the reference correct-by-construction):**
- `src/index.ts` — added `export * from './types.js'` so `TaskDef`, `TaskContext`, `Logger`, `SkierItem`, `SkierGlobals` are actually importable from the package root (additive, non-breaking; the docs already assumed this). This is the dogfooding-surfaces-a-gap case James called out.
- `src/types.ts` and each `src/builtins/*/index.ts` — added `// #region …` markers around the interfaces the docs transclude (config, and the produced-type/factory regions), so includes are stable across edits rather than line-number-fragile.
- `src/index.test.ts` (new) — a compile-time guard: it type-imports the five core types from the package root, so if `src/index.ts` ever stops re-exporting them the suite goes red (TS2305) and the docs can't silently drift from the real exports.

### Verification (all green, run for real)

- `npm run build` (tsc) — clean, exit 0.
- `npm test` — **123 passed / 19 suites** (122 before + the new export guard).
- `npm run docs:build` — exit 0. A broken `@include` throws and fails the build, so this exercises every directive. Confirmed in the rendered HTML: `task-contract` transcludes `src/types.ts` (×3) and `copyStaticTask` (×2); `config-interfaces` transcludes **all 12** built-in configs; every one of the 12 task pages renders its config from source; `#region` markers are stripped from all transcluded output; and the `NavItem.active?` drift is now gone.
- `npm run format:check` (CI prettier gate) — clean.

Build output (`/public`, `dist/`) is gitignored, so the diff is source + docs + the one test.

### What I deliberately did not do

- **Did not restyle anything** — visual design (Demi's bundle) is a separate, later task. This is reference content + frontmatter + `@include` wiring only.
- **Did not rewrite the existing task pages' prose or option tables** — they're good; I added the authoritative type signature alongside them rather than churning A1's content.
- **Did not surface the internal markdown-renderer utilities** (`renderMarkdown`, `Heading`, etc.) as public API — they aren't exported from the package root, so claiming they were would be wrong. Documented only the real export surface.

SUMMARY: Built Skier's reference docs — a full API Reference for the `TaskDef`/`TaskContext` authoring contract plus `@include`-wired type signatures across all 12 task pages — dogfooding `@include` from real source throughout, and fixed the package to actually export the core contract types the docs reference.

DECISIONS:
- **Exporting the core contract types from the package root.** I added `export * from './types.js'` to `src/index.ts` so `import type { TaskDef, TaskContext } from 'skier'` (which the docs instruct) actually works. Options: (a) keep it — makes the documented authoring API real and is non-breaking, additive, and guarded by a test (my recommendation, and the "dogfooding surfaces gaps" outcome you asked for); (b) revert the export and instead reword the docs to present tasks as a duck-typed plain-object shape with no importable types. I went with (a); flag if you'd rather keep `src/types.ts` internal.

---
_Opened by Tom from Slack._