### PR TITLE
Rewrite Skier quickstart for sub-10min onboarding flow

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,22 +4,40 @@ section: Getting Started
 order: 1
 ---
 
-# Get Started with Skier
+# Quick Start
 
 Skier is a static site generator you drive from a plain list of **tasks**. You
 describe your build as a pipeline — clean the output, render pages, copy assets —
-and the `skier` CLI runs it top to bottom. There is no scaffolding step and no
-hidden config: a project is a `skier.tasks.mjs` file plus your source.
+and the `skier` CLI runs it top to bottom. There is no scaffold step and no hidden
+config: a project is one `skier.tasks.mjs` file plus your source.
 
-This guide takes you from nothing to a **deployed site in under 10 minutes**.
-Start with the copy-paste happy path, then read the sections below to understand
-each piece.
+This guide takes you from an empty folder to a **live site in under ten minutes**.
+Every command is copy-paste-ready; do them in order.
+
+:::note Prerequisites
+Skier needs **Node.js ≥ 22.17** (this repo pins `22.17.1` in `.nvmrc`) and npm.
+Check with `node --version` before you start. The deploy step at the end also
+uses a free [Firebase](https://console.firebase.google.com/) project — you can
+stop after the preview step if you only want a local build.
+:::
+
+At a glance, the whole path:
+
+| Step | What you do | Time |
+|------|-------------|------|
+| 1 | [Create a project and install Skier](#1-create-a-project-2-min) | ~2 min |
+| 2 | [Write your first page](#2-write-your-first-page-1-min) | ~1 min |
+| 3 | [Define the pipeline](#3-define-the-pipeline-1-min) | ~1 min |
+| 4 | [Build](#4-build-30-sec) | ~30 sec |
+| 5 | [Preview locally](#5-preview-locally-30-sec) | ~30 sec |
+| 6 | [Deploy to Firebase Hosting](#6-deploy-to-firebase-hosting-4-min) | ~4 min |
 
 ---
 
-## The 2-minute version
+## 1. Create a project (~2 min)
 
-Run these commands, create the two files, and build:
+Make a folder, initialise a package, and add Skier as a dev dependency. The two
+`src/` directories are where your pages and shared partials will live:
 
 ```bash
 mkdir my-site && cd my-site
@@ -28,9 +46,31 @@ npm install --save-dev skier
 mkdir -p src/pages src/partials
 ```
 
-**`src/pages/index.html`** — your first page:
+That leaves you with the smallest layout that builds:
 
-```html
+```text
+my-site/
+├── src/
+│   ├── pages/          # your pages (Handlebars-enabled HTML)
+│   └── partials/       # shared template partials (may be empty)
+├── skier.tasks.mjs     # your build pipeline (created in step 3)
+└── package.json
+```
+
+:::note
+Skier imposes no fixed layout — tasks point at whatever directories you name.
+But `generatePagesTask` **reads** its `partialsDir`, so that folder must exist
+even when you have no partials yet. `mkdir -p src/partials` is enough.
+:::
+
+---
+
+## 2. Write your first page (~1 min)
+
+Create `src/pages/index.html`. Pages are ordinary HTML with Handlebars available,
+so `{{variables}}` and partials work — but plain HTML is a valid page too:
+
+```html title="src/pages/index.html"
 <!doctype html>
 <html lang="en">
   <head>
@@ -43,9 +83,14 @@ mkdir -p src/pages src/partials
 </html>
 ```
 
-**`skier.tasks.mjs`** — your pipeline:
+---
 
-```js
+## 3. Define the pipeline (~1 min)
+
+Your build lives in `skier.tasks.mjs`. It must **export a `tasks` array** — a
+named export called `tasks` is exactly what the CLI loads:
+
+```js title="skier.tasks.mjs"
 import { prepareOutputTask, generatePagesTask } from 'skier';
 
 export const tasks = [
@@ -58,93 +103,45 @@ export const tasks = [
 ];
 ```
 
-Build it and preview:
+Tasks run **in array order** — ordering *is* your build's control flow:
 
-```bash
-npx skier
-npx serve public
-```
+- [`prepareOutputTask`](./task-reference/prepareOutputTask.md) cleans and
+  recreates `public/` so each build starts from a blank slate.
+- [`generatePagesTask`](./task-reference/generatePagesTask.md) compiles every
+  `.html` file in `pagesDir` through Handlebars (registering any partials from
+  `partialsDir`) and writes the result to `outDir`.
 
-Open the printed URL and you'll see your page. That's a complete Skier build —
-everything below is detail and how to grow it.
-
----
-
-## Install Skier
-
-Skier needs **Node.js ≥ 22.17** (this repo pins `22.17.1` in `.nvmrc`) and npm.
-Check your version, then install Skier as a dev dependency:
-
-```bash
-node --version        # must be >= 22.17
-npm install --save-dev skier
-```
+:::tip
+Skier auto-detects the config file, trying `skier.tasks.js`, then `.mjs`,
+`.cjs`, and `.ts` in that order. This guide uses **`.mjs`** because it works
+regardless of your package's `type` field.
+:::
 
 ---
 
-## Lay out a minimal project
+## 4. Build (~30 sec)
 
-Skier imposes no fixed layout — you point tasks at whatever directories you like.
-The smallest project that builds looks like this:
-
-```
-my-site/
-├── src/
-│   ├── pages/
-│   │   └── index.html      # your pages (Handlebars-enabled HTML)
-│   └── partials/           # shared template partials (may be empty)
-├── skier.tasks.mjs         # your build pipeline
-└── package.json
-```
-
-> **Note:** `generatePagesTask` reads its `partialsDir`, so that directory must
-> exist even if you have no partials yet. `mkdir -p src/partials` is enough.
-
----
-
-## Define your pipeline
-
-Your build lives in `skier.tasks.mjs`. It must **export a `tasks` array** (a
-named export — this is what the CLI looks for):
-
-```js
-import { prepareOutputTask, generatePagesTask } from 'skier';
-
-export const tasks = [
-  prepareOutputTask({ outDir: 'public' }),
-  generatePagesTask({
-    pagesDir: 'src/pages',
-    partialsDir: 'src/partials',
-    outDir: 'public',
-  }),
-];
-```
-
-Tasks run **in array order**, so ordering is your build's control flow:
-
-- `prepareOutputTask` cleans and recreates `public/` so each build starts fresh.
-- `generatePagesTask` compiles every `.html` file in `pagesDir` through
-  Handlebars (registering any partials from `partialsDir`) and writes the result
-  to `outDir`.
-
-Skier auto-detects the config file in your project root, trying
-`skier.tasks.js`, then `.mjs`, `.cjs`, and `.ts` in that order. Use whichever
-suits your setup — `.mjs` works regardless of your package's `type` field, which
-is why this guide uses it.
-
----
-
-## Run the build
-
-Run the CLI directly:
+Run the CLI:
 
 ```bash
 npx skier
 ```
 
-…or wire it into `package.json` so it's part of your normal workflow:
+You'll see each task start and finish, and your site lands in `public/`:
 
-```json
+```text
+ℹ️ [skier/runner] Started
+ℹ️ [skier/prepare-output] Started task
+ℹ️ [skier/prepare-output] Finished task
+ℹ️ [skier/generate-pages] Started task
+ℹ️ [skier/generate-pages] Finished task
+ℹ️ [skier/runner] Completed
+```
+
+Prefer a script? Add one to `package.json` and use `npm run build` instead —
+it's the same command:
+
+```json title="package.json"
 {
   "scripts": {
     "build": "skier"
@@ -152,29 +149,17 @@ npx skier
 }
 ```
 
-```bash
-npm run build
-```
-
-Either way, your generated site lands in `public/`. The CLI accepts a few flags:
-
-| Flag | Effect |
-|------|--------|
-| `--debug` | Verbose per-task logging (paths written, partials registered, …). |
-| `--only <names>` | Run only the named tasks, comma-separated (e.g. `--only generate-pages`). |
-| `--skip <names>` | Run everything **except** the named tasks. |
-
-Task names come from the built-ins themselves — the pipeline above exposes
-`prepare-output` and `generate-pages`. Add `--debug` first when a build does
-something unexpected:
-
-```bash
-npx skier --debug
-```
+:::tip
+If a build does something unexpected, re-run with `npx skier --debug` for
+per-task logging (paths written, partials registered, …). You can also narrow a
+run with `--only <names>` or `--skip <names>` (comma-separated task names, e.g.
+`--only generate-pages`). Task names come from the built-ins — the pipeline
+above exposes `prepare-output` and `generate-pages`.
+:::
 
 ---
 
-## Preview locally
+## 5. Preview locally (~30 sec)
 
 Skier writes plain static files, so any static server works. The quickest:
 
@@ -182,57 +167,21 @@ Skier writes plain static files, so any static server works. The quickest:
 npx serve public
 ```
 
-That serves `public/` on a local port and prints the URL. Re-run `npx skier`
-(in another terminal) whenever you change a source file, then refresh.
+Open the printed URL and you'll see your page. Re-run `npx skier` whenever you
+change a source file, then refresh. **That's a complete Skier build** — the rest
+is deploying it and growing the pipeline.
 
 ---
 
-## Grow the pipeline
-
-Adding capability means adding tasks — the shape never changes. A few common
-"how do I…" steps:
-
-**Share values across templates** with `setGlobalsTask`. Globals are available
-to every template as `{{variable}}`:
-
-```js
-import { setGlobalsTask } from 'skier';
-
-setGlobalsTask({ values: { year: new Date().getFullYear(), siteName: 'My Site' } }),
-```
-
-```html
-<footer>© {{year}} {{siteName}}</footer>
-```
-
-**Ship CSS and assets** with `bundleCssTask` (concatenate + minify) and
-`copyStaticTask` (copy verbatim):
-
-```js
-import { bundleCssTask, copyStaticTask } from 'skier';
-
-copyStaticTask({ from: 'src/static', to: 'public' }),
-bundleCssTask({ from: 'src/css', to: 'public/assets', output: 'site.min.css', minify: true }),
-```
-
-**Write pages in Markdown** with `generateItemsTask`, which renders a directory
-of Markdown files (frontmatter and all) through a Handlebars template. See the
-[Task Reference](./task-reference/index.md) for its full options — and for the other
-built-ins (`generateNavDataTask`, `generateFeedTask`, `generateSitemapTask`,
-`generatePaginatedItemsTask`).
-
-Order still matters: put `prepareOutputTask` first, set globals before the tasks
-that read them, and generate content before feeds or sitemaps that index it.
-
----
-
-## Deploy to Firebase Hosting
+## 6. Deploy to Firebase Hosting (~4 min)
 
 Skier's output is a static `public/` directory, so it deploys anywhere. Skier's
 own docs site (the one you're reading) is built by Skier and deployed to
 **Firebase Hosting** — here's that same flow for your site.
 
-Install the Firebase CLI and sign in:
+You'll need a free Firebase project first: create one at
+[console.firebase.google.com](https://console.firebase.google.com/) and note its
+**project ID**. Then install the CLI and sign in:
 
 ```bash
 npm install --save-dev firebase-tools
@@ -241,7 +190,7 @@ npx firebase login
 
 Add a **`firebase.json`** pointing Firebase at your build output:
 
-```json
+```json title="firebase.json"
 {
   "hosting": {
     "public": "public",
@@ -251,26 +200,49 @@ Add a **`firebase.json`** pointing Firebase at your build output:
 }
 ```
 
-Build, then deploy:
+Build, then deploy — pass your project ID with `--project` (or run
+`npx firebase use --add` once to save it in a `.firebaserc`):
 
 ```bash
 npx skier
-npx firebase deploy --only hosting
+npx firebase deploy --only hosting --project your-project-id
 ```
 
-To share a change before it goes live, deploy to a temporary preview URL instead:
+The CLI prints your live **Hosting URL**. To share a change before it goes live,
+deploy to a temporary preview channel instead:
 
 ```bash
-npx firebase hosting:channel:deploy preview
+npx firebase hosting:channel:deploy preview --project your-project-id
 ```
 
-> Skier's docs deploy uses a slightly richer setup — separate **staging** and
-> **production** hosting targets in `firebase.json` and `.firebaserc` — so
-> changes ship to staging first. Look at those two files in the
-> [Skier repo](https://github.com/Ripixel-Studio/skier) for the real, dogfooded
-> configuration.
+:::note Skier's own docs go further
+Skier's docs deploy uses separate **staging** and **production** hosting targets
+in `firebase.json` + `.firebaserc`, so changes ship to staging first. See those
+two files in the [Skier repo](https://github.com/Ripixel-Studio/skier) for the
+real, dogfooded configuration.
+:::
 
-That's install → build → preview → deploy. You now have a live site.
+**Install → build → preview → deploy, done.** You have a live site.
+
+---
+
+## Grow the pipeline
+
+Adding capability means adding tasks — the shape never changes. A few common
+next moves:
+
+- **Share values across templates** with
+  [`setGlobalsTask`](./task-reference/setGlobalsTask.md). Globals are available to
+  every template as `{{variable}}`.
+- **Ship CSS and assets** with
+  [`bundleCssTask`](./task-reference/bundleCssTask.md) (concatenate + minify) and
+  [`copyStaticTask`](./task-reference/copyStaticTask.md) (copy verbatim).
+- **Author pages in Markdown** with
+  [`generateItemsTask`](./task-reference/generateItemsTask.md), which renders a
+  directory of Markdown files (frontmatter and all) through a Handlebars template.
+
+Order still matters: keep `prepareOutputTask` first, set globals before the tasks
+that read them, and generate content before the feeds or sitemaps that index it.
 
 ---
 
@@ -278,12 +250,12 @@ That's install → build → preview → deploy. You now have a live site.
 
 | Guide | Why |
 |-------|-----|
-| [Architecture](./architecture.md) | Understand how Skier works under the hood |
+| [Configuration](./configuration.md) | Config-file options, CLI flags, and patterns |
 | [Task Reference](./task-reference/index.md) | Every built-in task and its options |
 | [Markdown & Frontmatter](./markdown-frontmatter.md) | Author content in Markdown |
 | [Templates & Partials](./templates-partials.md) | Handlebars templating and shared partials |
 | [Custom Tasks](./custom-tasks.md) | Write your own task when a built-in doesn't fit |
-| [Configuration](./configuration.md) | Config file options and patterns |
+| [Architecture](./architecture.md) | How Skier works under the hood |
 | [Recipes](./recipes.md) | Complete, real-world pipelines |
 
 Stuck? The [FAQ](./faq.md) covers common build errors.


### PR DESCRIPTION
I'll start by understanding the current state: the spec, what A1 landed (the IA conventions), and the existing docs tree.
Let me read the current getting-started doc and understand the A1 frontmatter conventions from already-restructured pages.
This existing `getting-started.md` already reads like a polished quickstart. Since A2 "was cut off and never replayed," I need to determine whether this is pre-A2 content and verify every command against the real source. Let me investigate the package internals.
Let me read the CLI source to verify the flags, config resolution, and task names, and check the bin file.
Now let me verify the config file resolution and export contract — the current quickstart claims a named `export const tasks` is required, but the task-reference index uses `export default`.
Key verification results:
- `loadTasks` requires a **named** `export const tasks` array (line 27) — the quickstart's claim is **correct** (note: `task-reference/index.md` uses `export default`, which would actually fail, but that's an A3 file, out of my scope — I'll flag it).
- Config resolution order `.js → .mjs → .cjs → .ts` ✓
- Task names `prepare-output`, `generate-pages` ✓
- Node `>=22.17.0` engines / `.nvmrc` 22.17.1 ✓
- Flags `--debug`, `--only`, `--skip` (comma-separated) ✓

The existing quickstart is accurate but long/duplicative for a "<10 min" promise. Let me check the README, the docs build config, and the B-feature docs (callouts, copy-code, transclusion) so my rewrite uses current conventions. Let me also build the package and baseline the tests.
Let me survey the frontmatter across all docs to understand section membership and ordering, so my rewrite slots into the A1 IA cleanly.
Now let me build the package and verify the happy path end-to-end — the real test of "copy-paste-correct." I'll build, run the test suite, and smoke-test the documented commands against the local build.
Dependencies aren't installed. Let me install and build.
Build succeeds. Now let me run the test suite (baseline) and smoke-test the exact quickstart happy path against the local build.
All 123 tests pass. Now let me smoke-test the exact happy-path pipeline against the built CLI in a scratch dir inside the worktree (cleaned up after).
The exact happy path works end-to-end and all 123 tests pass. Task names, exports, and output are all confirmed correct.

Now I understand the full picture. The existing quickstart is *accurate* but long and duplicative (a "2-minute version" that then repeats install/pipeline/run in full), and it predates the merged B-features so it uses bold-filename headers and blockquotes instead of the now-available `title=` code labels and `:::` callouts. My A2 rewrite will be a tight, timed, task-oriented path that dogfoods B2/B4 and slots into the A1 IA.

One accuracy gap I'll fix: the old deploy step runs `firebase deploy` with no linked project, which fails without a `.firebaserc`/project — I'll make that honest.

Let me write the rewrite.
Let me verify my anchor links match B1's actual slug algorithm so the "At a glance" table links resolve.
All anchors match B1's slug algorithm. Now the real test — run the full docs build to confirm my page (callouts, `title=` fences, links) renders without breaking anything.
Build is clean. Let me confirm my page actually rendered the callouts and code labels correctly in the output HTML.
Callouts (B4) and filename labels (B2) both render. Let me confirm the heading anchors landed (my grep regex was too strict).
All anchors and internal links resolve. Let me confirm `public/` (the build output) is gitignored so it doesn't leak into the PR, then clean it up.
Only `docs/getting-started.md` changed; build artifacts are all gitignored. During verification I noticed a copy-paste bug in a sibling (A3) file worth flagging — let me confirm its scope before writing it up.
Let me confirm these `export default [...]` occurrences are genuinely `skier.tasks` examples (which would fail against `loadTasks`), not unrelated arrays.
Confirmed: these are all `skier.tasks.mjs` examples using `export default [...]`, which the real `loadTasks` **rejects** (it requires a named `export const tasks`). That's a systemic copy-paste bug across ~12 docs files that directly contradicts the correct pattern — a genuine finding for the PR.

My work is verified end-to-end. Here's the PR body.

---

## Rewrite the Skier quickstart for a <10-minute install → build → deploy (Task A2)

### What this is
Task **A2** of the docs-site-revamp spec: rewrite `docs/getting-started.md` so a new user gets from an empty folder to a live site in under ten minutes — task-oriented, copy-paste-correct, built on the merged A1 information architecture.

### Context / what I found first
A2's original run was cut off by a gateway restart and never replayed, so I checked what actually landed on `main` before touching anything:

- **A1 (IA)** had left `getting-started.md` accurate but **long and duplicative** — a "2-minute version" up top that then repeated install / pipeline / run in full detail (290 lines). For a page whose whole promise is "under 10 minutes," the duplication works against it.
- It **predated the merged B-features**, so it labelled files with bold `**`src/file`**` headers and used `>` blockquotes — where B2 (`title=` code labels) and B4 (`:::` callouts) now exist and are exactly what a docs page should dogfood.
- One real inaccuracy: the deploy step ran `firebase deploy --only hosting` with **no linked project**, which fails without a `.firebaserc`/project.

I verified every technical claim against source rather than trusting the prose:
- `loadTasks` requires a **named `export const tasks`** array (not a default export) — confirmed in `src/cli/loadTasks.ts:27`.
- Config resolution order `.js → .mjs → .cjs → .ts`, task names `prepare-output` / `generate-pages`, flags `--debug` / `--only` / `--skip`, Node `>=22.17.0` (`.nvmrc` 22.17.1) — all confirmed.

### What I changed
A focused rewrite of `docs/getting-started.md` (the only file touched):

- **A timed, six-step happy path** — Create project → Write a page → Define pipeline → Build → Preview → Deploy — each step tagged with a time budget summing to ~9 min, plus an "At a glance" table at the top that links to each step. The `<10 min` promise is now structural, not just asserted.
- **Removed the duplicated "2-minute version"** — the fast path *is* the page now; concept-heavy detail (CLI-flag table, config-resolution trivia, "grow the pipeline") is compressed into callouts/tips or linked out to Guides/Configuration/Task Reference.
- **Dogfoods the merged B-features**: `title=` fence labels for every filename (`skier.tasks.mjs`, `firebase.json`, …) and `:::note` / `:::tip` callouts for the prerequisites, the partials-dir gotcha, and the debug tips.
- **Honest deploy step**: notes you need a free Firebase project, and deploys with `--project your-project-id` (or `firebase use --add`) so the commands actually work as written.
- Wired into the A1 IA unchanged: `title: Quick Start`, `section: Getting Started`, `order: 1`; internal links point at the merged A3 task/API reference pages.

### Verification
- `npm ci && npm run build` clean; **`npm test` → 19 suites, 123 tests, all pass** (docs-only change; nothing broken).
- **Smoke-tested the exact happy path** end-to-end against the built CLI in a scratch project: the documented `export const tasks` pipeline (`prepareOutputTask` + `generatePagesTask`) runs and produces `public/index.html`. Task-log output in the doc is copied from that real run.
- **Ran the full docs build** (`skier.tasks.cjs`) on the new page — exit 0, no errors. Confirmed in the rendered HTML: 3 note + 2 tip callouts (B4), `data-filename` labels on all four config blocks (B2), and all six heading `id`s match the "At a glance" anchor links (verified against B1's `slugify`).
- All 14 internal link targets exist on disk.
- Build artifacts (`public/`, `dist/`, `node_modules/`, scratch dir) are gitignored / removed — only `docs/getting-started.md` is in the diff.

### What I deliberately did *not* do
- Did **not** touch any other docs page, the design/templates (A4/A5), or search UI (A6) — out of A2's scope.
- Did **not** fix the `export default` discrepancy I found across ~12 other docs files (see decision below) — it spans other tasks' files and may warrant a package change, so it's not mine to resolve unilaterally.
- No screenshots: this is Markdown content whose visual rendering is owned by the A4/A5 design pass, which hasn't landed — there's no styled page to shoot yet.

SUMMARY: Rewrote `docs/getting-started.md` into a timed, task-oriented, copy-paste-verified <10-minute install→build→deploy quickstart that dogfoods the merged copy-code labels and callouts.

DECISIONS:
- **The docs contradict the CLI on how a `skier.tasks` file exports its tasks.** `loadTasks` (`src/cli/loadTasks.ts:27`) requires a **named `export const tasks = [...]`** and rejects anything else with "does not export a tasks array." My new quickstart uses the correct named export (smoke-tested working), but **~12 other docs files** (`configuration.md`, `task-reference/index.md`, `recipes.md`, `tasks.md`, `migration.md`, `architecture.md`, several task-reference pages, …) show `export default [...]`, which would fail as written. Two ways to make them consistent: **(a)** fix the docs — change `export default [...]` → `export const tasks = [...]` across those files (content-only, matches shipping behaviour); or **(b)** extend `loadTasks` to also accept a default export (a small B-type package change — `export default` is the more idiomatic ESM shape, and it makes the existing examples correct). My recommendation: **(b)** accept both in `loadTasks`, then the named form stays canonical in the quickstart and no existing example is a lie — the more forgiving CLI is better DX and turns a docs-wide fix into one small package change. Either way it's a follow-up issue, not part of this PR.

---
_Opened by Tom from Slack._