### PR TITLE
Fix CI failure on main branch after recent merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,16 +59,20 @@ jobs:
             git config user.name "CircleCI"
             git remote set-url origin git@github.com:ripixel/skier.git
       - run:
-          name: Publish via npm trusted publishing (OIDC)
+          name: Publish via semantic-release
           command: |
-            # Exchange CircleCI's OIDC token for a short-lived npm publish token.
-            # semantic-release/npm >= 13.1 detects NPM_ID_TOKEN and uses trusted
-            # publishing instead of a long-lived NPM_TOKEN. No npm token required.
-            # cimg/node:22.17.0 ships npm 10.9.x, but the OIDC token -> publish
-            # credential exchange needs npm CLI >= 11.5.1. Upgrade before publishing.
-            # cimg/node requires sudo for global installs (npm prefix is root-owned).
-            sudo npm install -g npm@^11.5.1
-            export NPM_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')"
+            # Authenticates to npm with the NPM_TOKEN env var (an npm automation
+            # token) configured in the CircleCI project settings. @semantic-release/npm
+            # reads NPM_TOKEN automatically.
+            #
+            # NOTE: npm "trusted publishing" (OIDC) is NOT usable here. As of
+            # @semantic-release/npm v13.1, the OIDC token exchange only runs when
+            # env-ci reports the provider as "GitHub Actions" or "GitLab CI/CD"
+            # (see lib/trusted-publishing/token-exchange.js). On CircleCI env-ci
+            # reports "CircleCI", so the exchange is skipped, NPM_ID_TOKEN is never
+            # read, and the plugin falls back to token auth. Minting an NPM_ID_TOKEN
+            # therefore does nothing on CircleCI. Keep NPM_TOKEN until npm trusted
+            # publishing gains a CircleCI provider.
             npx semantic-release
   build_docs:
     executor: node-executor


### PR DESCRIPTION
I'll investigate the CI failure. Let me start by understanding the repo and its CI configuration.
Let me reproduce the CI-reproducible steps locally (build, test, format), then dig into the release job specifically.
Build, format, and all 123 tests pass locally. So the `release` job isn't failing on those upstream steps — it's failing in its own `npx semantic-release` step. Let me reproduce that. First, note there are **two** semantic-release configs (`.releaserc` and a `release` key in `package.json`). Let me check the git history of the release-relevant files and try a dry run.
The dual config has existed since July 2025 with successful releases since — not a new cause. The `release` job's own step is `npx semantic-release`, and the last change to `.circleci` was #43 (the npm upgrade). Let me examine that diff and the release step closely.
Let me actually reproduce the release step. I'll run `semantic-release` in dry-run to surface config/plugin errors without publishing.
The dry run reveals something important: only the **default** plugin set loaded (`commit-analyzer`, `release-notes-generator`, `npm`, `github`) — **not** the `changelog` and `git` plugins listed in `.releaserc`. That confirms `package.json`'s `release` key wins in cosmiconfig and `.releaserc` is silently ignored. But that's long-standing. Let me find what's actually releasable on main and check the last tag/version.
Latest npm publish is `3.4.0`, tags go to `v3.4.0`, but recent main commits (#41–#44) have no conventional-commit prefixes, so semantic-release would determine "no release" and exit 0 — *unless* it fails earlier in `verifyConditions`, which runs first. Let me inspect what `@semantic-release/npm`'s verifyConditions requires regarding the OIDC/trusted-publishing setup.
This is the smoking gun. Let me confirm: `@semantic-release/npm`'s OIDC trusted-publishing only supports **GitHub Actions** and **GitLab Pipelines** — CircleCI takes neither branch. Let me verify the provider constants, what `env-ci` reports for CircleCI, and the history of how the release job's npm auth evolved.
Confirmed the root cause. Now let me trace the history of the release job's npm auth to understand what changed from green to red.
The history confirms the timeline precisely. Let me verify how `verifyConditions` wires up `verifyAuth`, and confirm the pre-OIDC config that successfully published v1.8.0→v3.4.0.
Everything is confirmed. Let me lay out the complete causal chain before fixing:

- `verifyConditions` in `@semantic-release/npm` (index.js:33) **always** calls `verifyNpmAuth` on every run — even a "no release" run — so the `release` job fails on *every* push to main.
- `verifyNpmAuth` → `oidcContextEstablished` returns `false` on CircleCI because the plugin's `exchangeToken` only matches `"GitHub Actions"` or `"GitLab CI/CD"` (env-ci reports `"CircleCI"`). So `NPM_ID_TOKEN` is never read, OIDC never happens, and it falls through to token auth (`npm whoami`) → `EINVALIDNPMTOKEN`.
- Pre-OIDC (which published v1.8.0→v3.4.0 successfully), the release step was just `- run: npx semantic-release`, authenticating via a `NPM_TOKEN` env var. PR #40 replaced that with an OIDC path npm trusted-publishing **does not support on CircleCI**; PR #43 tried to patch it with an npm-CLI upgrade, but the premise was wrong.

The smallest real fix: restore the token-based publish step and drop the dead OIDC/npm-upgrade lines. Let me view and edit the release job.
Now let me verify the YAML is valid and that prettier is still happy with the change.
The `NPM_ID_TOKEN` string only remains in my explanatory comment; the actual `export NPM_ID_TOKEN=...` and `circleci run oidc get` lines are gone. Let me confirm, and run the full local test suite once more to make sure nothing regressed.
All green locally: build passes, 123/123 tests pass, prettier clean, and the dead OIDC/npm-upgrade lines are gone. The fix is complete and minimal.

---

## What was wrong

`ci/circleci: release` has been red on `main` since **PR #40** ("Enabled npm trusted publishing (OIDC)"), with **PR #43** ("Upgrade npm CLI to ≥11.5.1") a follow-up that tried to patch the same broken approach. Both were built on a false premise.

**The causal chain (verified against the installed plugin source, not guessed):**

1. The `release` job runs `npx semantic-release`. `@semantic-release/npm`'s `verifyConditions` calls `verifyNpmAuth` on **every** run — even a "no new release" run — so this fails on *every* push to `main`, red for everyone, no PR owning it.
2. `verifyNpmAuth` → `oidcContextEstablished` (`lib/trusted-publishing/oidc-context.js`) → `exchangeToken` (`token-exchange.js`). That function only performs the OIDC exchange when `env-ci` reports the CI provider as **`"GitHub Actions"`** or **`"GitLab CI/CD"`**. I confirmed `env-ci` reports **`"CircleCI"`** here (`name: CircleCI | service: circleci`), so it matches neither branch and returns `undefined`.
3. So the `NPM_ID_TOKEN` that #40 mints via `circleci run oidc get` is **never read** — the plugin only reads `NPM_ID_TOKEN` inside the *GitLab* branch, and only after confirming the provider is GitLab. On CircleCI the OIDC path is dead code.
4. With no OIDC context, the plugin falls back to token auth (`npm whoami`). Since #40 removed the long-lived npm token ("No npm token required"), there's no valid credential → `EINVALIDNPMTOKEN` → job fails.
5. #43's `sudo npm install -g npm@^11.5.1` couldn't help: the blocker isn't the npm CLI version, it's that **npm trusted publishing has no CircleCI provider at all**. The npm-CLI upgrade served only the unsupported path.

This is why every version from **v1.8.0 through v3.4.0** published fine (the old job was a plain `- run: npx semantic-release` authenticating via `NPM_TOKEN`), and nothing has published since #40 (npm `latest` is stuck at `3.4.0`).

## What I changed

`.circleci/config.yml`, `release` job only — reverted the publish step to the token-based flow that worked through v3.4.0:

- Removed the `sudo npm install -g npm@^11.5.1` line and the `export NPM_ID_TOKEN="$(circleci run oidc get ...)"` line — both only existed to serve the OIDC path the plugin can't use on CircleCI.
- Restored a plain `npx semantic-release`, which authenticates via the `NPM_TOKEN` env var read automatically by `@semantic-release/npm`.
- Left a comment explaining *why* OIDC trusted publishing isn't usable here (with the file reference), so this isn't re-attempted.

No dependency, source, or test changes. `@semantic-release/npm` stays at v13 — it works fine with `NPM_TOKEN`; the version bump wasn't the problem, the auth mechanism was.

## Testing evidence

- `npm run build` (tsc) — clean.
- `npm test` — **123 passed, 123 total** (19 suites).
- `npm run format:check` (prettier, as the `prettier` CI job runs) — clean, including the edited YAML.
- Confirmed via `env-ci` locally that CircleCI reports provider `"CircleCI"`, and read `token-exchange.js` to confirm only `"GitHub Actions"`/`"GitLab CI/CD"` are handled.

The one thing I **cannot** verify from here is whether the `NPM_TOKEN` secret still exists in the CircleCI project settings — #40's migration explicitly moved *away* from it, so it may have been deleted. I don't touch CI secrets (house rule), so see the decision below.

## What I deliberately did not do

- Didn't try to make OIDC work on CircleCI — npm trusted publishing simply doesn't support CircleCI as a provider, so there's no config that makes it work with this plugin.
- Didn't add a `.github/workflows` GitHub Actions job (which *would* get real OIDC) — that contradicts the house convention that CI is CircleCI.
- Didn't touch the separate, pre-existing config smell where `package.json`'s `release` key shadows `.releaserc` (so `.releaserc`'s changelog/git plugins never load and only the default npm+github plugins run). It's long-standing, unrelated to this failure, and out of scope — I'll file a follow-up issue.
- Didn't weaken or skip any test.

SUMMARY: Restored the CircleCI `release` job to token-based npm auth (`NPM_TOKEN`), removing the OIDC trusted-publishing setup that `@semantic-release/npm` cannot use on CircleCI, which had left `main`'s release job red since PR #40.

DECISIONS:
- **`NPM_TOKEN` must be present in the CircleCI project settings for this fix to actually publish.** If #40 deleted it during the OIDC migration, `main` will still fail (same `EINVALIDNPMTOKEN`) until it's re-added — which needs an admin, as I can't touch CI secrets. Options: (a) an admin re-adds an npm automation/granular-access token as `NPM_TOKEN` in CircleCI [**recommended** — matches how v1.8.0→v3.4.0 published and keeps CI on CircleCI per house convention]; (b) move only the publish step to a minimal GitHub Actions workflow to use real OIDC trusted publishing [rejected: contradicts the CircleCI convention and is a much larger change]. Please confirm the token is set, or ask an admin to add it.

---
_Opened by Tom from Slack._