### PR TITLE
Fix broken CI on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,13 @@ jobs:
           command: |
             git config user.email "ci@skier.dev"
             git config user.name "CircleCI"
-            git remote set-url origin git@github.com:ripixel/skier.git
+            # Point the release remote at the canonical repository. CI runs on
+            # Ripixel-Studio/skier; the old ripixel/skier path is a stale personal
+            # remote. semantic-release has no `repository` field in package.json,
+            # so it derives its git-tag push target AND the @semantic-release/github
+            # release/permission-check target from this remote — it must match the
+            # repo CI actually operates on.
+            git remote set-url origin git@github.com:Ripixel-Studio/skier.git
       - run:
           name: Publish via semantic-release
           command: |


### PR DESCRIPTION
I'll start by understanding the repo structure, its CI config, and how tests/lint are run.
The failing job is `release` (runs `npx semantic-release`). Let me reproduce the CI steps locally and examine the release setup. First let me look at the repo structure and recent history.
Let me install dependencies and reproduce the CI steps that I can run locally.
Now let me run the CI steps (format:check, build, test) and check the npm version requirements for the release plugins.
All local checks pass (format:check, build, 123 tests). The failure is isolated to the `release` job (`npx semantic-release`). Let me investigate the release toolchain — recent commits (#43, #45, #46) all touched it. Let me check what `@semantic-release/npm` requires.
The OIDC note in the config is accurate — on CircleCI the exchange is skipped and it falls back to `NPM_TOKEN`. So that's not the bug. Let me trace the recent release-related commits to see what changed and whether a merge re-broke something.
Let me actually run `semantic-release` to observe where it fails. I'll force CI mode with dummy tokens and dry-run to capture the first real error class.
Interesting — the dry-run loaded only the **default** plugins (commit-analyzer, release-notes-generator, npm, github). The `@semantic-release/changelog` and `@semantic-release/git` plugins from `.releaserc` were **not** loaded. That means `package.json`'s `"release"` key is winning over `.releaserc`. Let me confirm and simulate the `main` branch to reproduce the real failure.
The `package.json` `"release"` key shadows `.releaserc` entirely (cosmiconfig checks `package.json` first). Let me check when that `"release"` key was introduced — this determines whether it's the regression.
Both configs have coexisted since the initial commit, so the dual-config is a latent smell, not the new regression. Let me reproduce the actual `main`-branch release path by simulating the CircleCI environment.
The dry-run stops early because our local `main` ref is behind `origin/main` (worktree artifact). Let me examine the exact current release job command and check the npm version situation, plus whether there are existing published versions/tags.
There are real tags up to `v3.4.0`, so token-auth releases have worked historically — the npm account owns `skier`. Let me see where the last successful release tag sits relative to the recent commits.
Let me examine the npm plugin's actual publish/prepare commands and check the image's default npm version compatibility — this is the thread the prior PRs kept pulling.
The publish uses plain token auth (no new npm needed). But I notice the release job hardcodes `git remote set-url origin git@github.com:ripixel/skier.git`, while the actual repo is `Ripixel-Studio/skier`. Let me investigate this mismatch and the SSH setup history.
85366d0 (which set `ripixel/skier`) is an ancestor of v3.4.0, and releases succeeded through v3.4.0 — so that remote worked at least until Feb 2026. #46's message claims release went red "since PR #40". Let me inspect #39/#40 to see what actually changed there.
Now I understand the saga. #39/#40 were a previous agent chasing npm OIDC trusted-publishing (which doesn't work on CircleCI), producing an `ENONPMTOKEN` failure. #45/#46 walked it back. Let me verify #46 faithfully restored the release job to its last-known-green state (before the #39 OIDC experiment).
The config is functionally identical to the last-green state (#46 restored it faithfully). So the config isn't the remaining cause — but the **dependencies** changed during the saga. Let me compare the pre-saga release toolchain versions against now.
The config is functionally identical to the last-green state. The leftover change from the saga is the **dependency churn**: semantic-release 24→25, @semantic-release/npm 12→13, @semantic-release/github 11→12 — bumped *only* to chase OIDC. Since #46 is already on main and release is still red, let me try to reach the actual `verifyConditions` error by treating the current branch as a release branch.
That error is just my synthetic branch not existing on the remote — `verifyConditions` (which needs real tokens) runs after branch resolution, so I can't reach it from this worktree. I have enough to conclude the diagnosis.

Let me consolidate the finding. The delta between the last **green** release (v3.4.0) and now is: (1) the release-job config — already restored by #46 — and (2) the dependency bumps (`semantic-release` 24→25, `@semantic-release/npm` 12→13, `@semantic-release/github` 11→12) that were made *only* to enable OIDC trusted publishing, which is confirmed unusable on CircleCI. #46 restored the config but left the dead OIDC dependency churn. Let me finish that revert — returning the release stack to its exact last-green state — and verify.
Let me characterize the commits since the last successful release to understand what the release job would attempt, which pins down whether the red is at `verifyConditions` (always runs, needs the token) or at publish.
This is the decisive finding: **none of the commits since `v3.4.0` are conventional-commit "releasing" commits** (no `feat:`/`fix:`/`perf:`/breaking). So `commit-analyzer` would decide "no release," and `publish` never runs. For the `release` job to be **red**, `semantic-release` must be failing at **`verifyConditions`** — which runs first, on every `main` build, and requires valid credentials (`npm whoami` via `NPM_TOKEN`, then GitHub token/push-permission). That's a credential/target failure, i.e. environmental — not a code bug in the app.

Let me pin down the one code-side discrepancy in that credential path: the release job forces `origin` to `ripixel/skier`, but the canonical repo (and where CI runs) is `Ripixel-Studio/skier`.
The release job resets `origin` to `git@github.com:ripixel/skier.git`, but the canonical repository — where CircleCI runs, and this worktree's `origin` — is `Ripixel-Studio/skier`. Since `package.json` has no `repository` field, `semantic-release` derives its GitHub target from that overridden remote, so `@semantic-release/github`'s `verifyConditions` push-permission check runs against the wrong repo path. That's a real, in-scope, low-risk correction in the exact failing path. Let me fix it.
Let me validate the YAML and re-run the formatting check (CI runs `prettier --check .`).
Let me do a proper YAML parse to be certain the CircleCI config is still valid.
Let me re-confirm the full reproducible CI suite passes with the change in place, for the PR's testing evidence.
All green — build clean, 123 tests pass, prettier clean. The change is a single 7-line edit to `.circleci/config.yml`.

Let me record the non-obvious gotcha that caused repeated thrash in this area, so future tasks don't re-run the saga.
Memory writes outside the worktree are blocked — that's fine, the full diagnosis lives in the PR body below.

---

## Fix CircleCI `release` job on `main`: point release remote at the canonical repo

### What was failing
`ci/circleci: release` is red on `main`. All the *other* jobs are fine — I ran the project's own CI steps locally in this worktree and they all pass:

- `npm ci` — clean
- `npm run format:check` (`prettier --check .`) — clean
- `npm run build` (`tsc`) — clean
- `npm test` (`jest`) — **19 suites, 123 tests, all passing**

So this is not a code, test, lint, or build regression. The failure is isolated to `release`, which runs `npx semantic-release`.

### Root cause analysis
Two facts pin down *where* `semantic-release` dies:

1. **No releasing commits since the last release.** The last published tag is `v3.4.0` (2026‑02‑07). Every commit since then is a squash‑merge whose subject does **not** parse as a conventional `feat:`/`fix:`/`perf:`/breaking commit (`Implement…`, `Rewrite…`, `Bump…`, `Task B5…`, `Fix CI failure…` with no `type:` prefix). So `commit-analyzer` decides "no release" and **`publish` never runs**.
2. Therefore the only stage that can turn the job red is **`verifyConditions`**, which `semantic-release` runs *first, on every `main` build*, before commit analysis. It requires valid credentials: `@semantic-release/npm` runs `npm whoami` against `NPM_TOKEN`, then `@semantic-release/github` checks the GitHub token's push permission on the target repo.

This means the red job is a **credential / target failure in `verifyConditions`**, which is consistent with the history here: this job was broken by an OIDC "trusted publishing" experiment (PRs #39/#40) that stopped using `NPM_TOKEN` and produced `ENONPMTOKEN`. OIDC does **not** work on CircleCI — `@semantic-release/npm` only performs the token exchange when `env-ci` reports "GitHub Actions" or "GitLab CI/CD" (I read `lib/trusted-publishing/token-exchange.js` to confirm this; the inline comment #46 added is accurate). #46 already restored the job's *config* to `NPM_TOKEN` auth (I diffed it — functionally identical to the last‑green pre‑#39 config), yet `main` is still red.

### What I changed and why
One concrete, in‑scope bug remained in that credential path: the release job forced the git remote to a repository that isn't the one CI runs on.

```
- git remote set-url origin git@github.com:ripixel/skier.git
+ git remote set-url origin git@github.com:Ripixel-Studio/skier.git
```

`package.json` has **no `repository` field**, so `semantic-release` derives *both* its git‑tag push target *and* the `@semantic-release/github` release/permission‑check target from this remote. This worktree's `origin` — and where the CircleCI project runs — is `Ripixel-Studio/skier`; the hardcoded `ripixel/skier` is a stale personal path (added long ago in 85366d0). Aligning it to the canonical repo is correct and low‑risk regardless: the release job must operate on the repo CI actually builds. If a repo transfer (personal → org) is why releases stopped, this is the fix; if GitHub redirects were previously masking it, this is still the right, direct target. I added a comment explaining the coupling so this doesn't get "cleaned up" back to the wrong value.

### What I deliberately did *not* do
- **I did not touch the `NPM_TOKEN` / GitHub secrets.** If `verifyConditions` is dying on `npm whoami` (the most likely case given the OIDC saga removed `NPM_TOKEN` usage), the credential itself must be restored/rotated in the **CircleCI project settings** — a secrets operation I'm not permitted to perform. **Action for James (→ #approvals): confirm `NPM_TOKEN` (an npm automation token) is present and valid in CircleCI, and that the GitHub release token is valid.** The remote fix above does not substitute for this; `npm` verification runs *before* the GitHub check, so if the npm token is missing/expired the job never reaches the remote at all.
- **I did not revert the OIDC‑era dependency bumps** (`semantic-release` 24→25, `@semantic-release/npm` 12→13, `@semantic-release/github` 11→12). They install and run cleanly locally and support `NPM_TOKEN` auth fine (I read the token path in `set-npmrc-auth.js`), so downgrading would be unproven churn that Renovate would immediately fight.
- **I did not "fix" the `.releaserc` vs `package.json` config shadowing.** `package.json`'s `release` key wins over `.releaserc` (cosmiconfig order), so `semantic-release` runs with default plugins and the `@semantic-release/changelog`/`git` plugins never load — this is why `package.json` is still `1.0.0` while tags reach `v3.4.0`. It's longstanding (present since the initial commit, and every release through `v3.4.0` shipped this way), so it is **not** this regression. "Fixing" it would newly enable `@semantic-release/git` pushing to `main` and risks colliding with branch protection — out of scope and riskier than leaving it.

### Net
This PR removes a genuine latent bug in the release job's target repo. If the remaining red is the GitHub‑side check, this greens it. If it's the npm token (the leading suspect), the job will stay red until the `NPM_TOKEN` secret is restored in CircleCI — flagged above for #approvals. Either way, nothing is papered over and the reproducible CI jobs are all green.

SUMMARY: Diagnosed the red `main` `release` job as a `verifyConditions` credential/target failure (not a code/test regression) and fixed the release job's git remote to point at the canonical `Ripixel-Studio/skier`, while flagging that a missing/expired CircleCI `NPM_TOKEN` is the likely remaining root cause and needs restoring via #approvals.

---
_Opened by Tom from Slack._